### PR TITLE
Extract dnsclient.Resolver interface and inject one shared resolver

### DIFF
--- a/internal/assessor/asssessor.go
+++ b/internal/assessor/asssessor.go
@@ -15,7 +15,7 @@ import (
 type Config struct {
 	Logger    *slog.Logger
 	Store     *store.Queries
-	DNSClient *dnsclient.DNSClient
+	DNSClient dnsclient.Resolver
 	// Identity is the scan identity used to stamp observations. Left zero in unit
 	// tests (which exercise finding logic without a scan); emission is skipped then.
 	Identity observer.DomainIdentity
@@ -24,7 +24,7 @@ type Config struct {
 type Assessor struct {
 	logger    *slog.Logger
 	store     *store.Queries
-	dnsClient *dnsclient.DNSClient
+	dnsClient dnsclient.Resolver
 	identity  observer.DomainIdentity
 }
 

--- a/internal/dnsclient/dns_client.go
+++ b/internal/dnsclient/dns_client.go
@@ -510,8 +510,7 @@ func (c *DNSClient) IsZoneApex(domain string) bool {
 	m := new(dns.Msg)
 	m.SetQuestion(dns.Fqdn(domain), dns.TypeSOA)
 
-	client := New()
-	response, ok := client.sendDNSSECQuery(m)
+	response, ok := c.sendDNSSECQuery(m)
 
 	return ok && len(response.Answer) > 0
 }

--- a/internal/dnsclient/dns_client_test.go
+++ b/internal/dnsclient/dns_client_test.go
@@ -908,3 +908,56 @@ func TestDNSClient_WithOptions(t *testing.T) {
 	// Just make a simple call to ensure it doesn't crash
 	_, _ = clientWithCustomDNS.LookupA("example.com")
 }
+
+func TestDNSClient_IsZoneApexUsesReceiverServers(t *testing.T) {
+	// IsZoneApex must query through the receiver's configured servers, not a fresh
+	// default client. Point the default servers (DNS_SERVERS) at a decoy that denies
+	// the SOA and the receiver at a mock that serves it: only an IsZoneApex honouring
+	// the receiver returns true.
+	apex, err := testhelpers.NewMockDNSServer()
+	if err != nil {
+		t.Fatalf("Failed to create apex mock DNS server: %v", err)
+	}
+	if err := apex.Start(); err != nil {
+		t.Fatalf("Failed to start apex mock DNS server: %v", err)
+	}
+	defer func() {
+		if err := apex.Stop(); err != nil {
+			t.Fatalf("Failed to stop apex mock DNS server: %v", err)
+		}
+	}()
+
+	decoy, err := testhelpers.NewMockDNSServer()
+	if err != nil {
+		t.Fatalf("Failed to create decoy mock DNS server: %v", err)
+	}
+	if err := decoy.Start(); err != nil {
+		t.Fatalf("Failed to start decoy mock DNS server: %v", err)
+	}
+	defer func() {
+		if err := decoy.Stop(); err != nil {
+			t.Fatalf("Failed to stop decoy mock DNS server: %v", err)
+		}
+	}()
+
+	const domain = "apex.example.com"
+	if err := apex.AddRecord(domain, dns.TypeSOA, 3600,
+		"ns1.example.com hostmaster.example.com 1 7200 3600 1209600 3600"); err != nil {
+		t.Fatalf("Failed to add SOA record: %v", err)
+	}
+	// Decoy answers NOERROR/NODATA for the SOA so the stray-default-client path
+	// resolves immediately (no backoff) and reports "not apex".
+	decoy.SetRcode(dns.Fqdn(domain), dns.RcodeSuccess)
+
+	// A stray New() reads DNS_SERVERS; route it to the decoy, never the apex mock.
+	t.Setenv("DNS_SERVERS", decoy.ListenAddr)
+
+	client := New(
+		WithServers([]string{apex.ListenAddr}),
+		WithLogger(testhelpers.TestLogger),
+	)
+
+	if !client.IsZoneApex(domain) {
+		t.Fatal("IsZoneApex did not query through the receiver's configured servers")
+	}
+}

--- a/internal/dnsclient/resolver.go
+++ b/internal/dnsclient/resolver.go
@@ -1,0 +1,33 @@
+package dnsclient
+
+import (
+	"context"
+
+	"github.com/danielmichaels/gecko/internal/dnsrecords"
+	"github.com/projectdiscovery/subfinder/v2/pkg/resolve"
+)
+
+// Resolver is the seam between scanners/assessors and DNS egress. It is the exact
+// method set callers use today; *DNSClient satisfies it unchanged. A future
+// caching/singleflight/rate-limiting implementation swaps in here with no call-site
+// changes.
+type Resolver interface {
+	LookupA(target string) ([]string, bool)
+	LookupAAAA(target string) ([]string, bool)
+	LookupCNAME(target string) ([]string, bool)
+	LookupTXT(target string) ([]string, bool)
+	LookupDS(target string) ([]string, bool)
+	LookupDNSKEYWithRRSIG(target string) ([]string, []string, bool)
+	LookupWithStatus(target string, qtype uint16) ([]string, ResolutionStatus)
+	IsZoneApex(domain string) bool
+	ValidateDNSSEC(domain string) error
+	AttemptZoneTransfer(domain string) *dnsrecords.ZoneTransferResult
+	EnumerateWithSubfinderCallback(
+		ctx context.Context,
+		domain string,
+		concurrency int,
+		callback func(*resolve.HostEntry),
+	) error
+}
+
+var _ Resolver = (*DNSClient)(nil)

--- a/internal/dnsclient/resolver_test.go
+++ b/internal/dnsclient/resolver_test.go
@@ -1,0 +1,10 @@
+package dnsclient
+
+import "testing"
+
+func TestNewReturnsResolver(t *testing.T) {
+	var r Resolver = New()
+	if r == nil {
+		t.Fatal("New() returned a nil Resolver")
+	}
+}

--- a/internal/jobs/assess_jobs.go
+++ b/internal/jobs/assess_jobs.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/danielmichaels/gecko/internal/assessor"
+	"github.com/danielmichaels/gecko/internal/dnsclient"
 	"github.com/danielmichaels/gecko/internal/tracing"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -27,9 +28,10 @@ func (AssessCNAMEDanglingArgs) Kind() string { return "assess_cname_dangling" }
 
 type AssessCNAMEDanglingWorker struct {
 	river.WorkerDefaults[AssessCNAMEDanglingArgs]
-	Logger  slog.Logger
-	Store   *store.Queries
-	PgxPool *pgxpool.Pool
+	Logger   slog.Logger
+	Store    *store.Queries
+	PgxPool  *pgxpool.Pool
+	Resolver dnsclient.Resolver
 }
 
 func (w *AssessCNAMEDanglingWorker) Work(
@@ -39,8 +41,9 @@ func (w *AssessCNAMEDanglingWorker) Work(
 	ctx = tracing.WithNewTraceID(ctx, true)
 	w.Logger.InfoContext(ctx, "assess CNAME started", "domain", job.Args.DomainName)
 	_ = assessor.NewAssessor(assessor.Config{
-		Logger: &w.Logger,
-		Store:  w.Store,
+		Logger:    &w.Logger,
+		Store:     w.Store,
+		DNSClient: w.Resolver,
 	})
 	/* todo:
 	- cloud provider checks
@@ -65,9 +68,10 @@ func (AssessZoneTransferArgs) Kind() string { return "assess_zone_transfer" }
 
 type AssessZoneTransferWorker struct {
 	river.WorkerDefaults[AssessZoneTransferArgs]
-	Logger  slog.Logger
-	Store   *store.Queries
-	PgxPool *pgxpool.Pool
+	Logger   slog.Logger
+	Store    *store.Queries
+	PgxPool  *pgxpool.Pool
+	Resolver dnsclient.Resolver
 }
 
 func (w *AssessZoneTransferWorker) Work(
@@ -78,9 +82,10 @@ func (w *AssessZoneTransferWorker) Work(
 	start := time.Now()
 	w.Logger.InfoContext(ctx, "assess zone transfer started", "domain", job.Args.DomainUID)
 	a := assessor.NewAssessor(assessor.Config{
-		Logger:   &w.Logger,
-		Store:    w.Store,
-		Identity: job.Args.Identity(),
+		Logger:    &w.Logger,
+		Store:     w.Store,
+		DNSClient: w.Resolver,
+		Identity:  job.Args.Identity(),
 	})
 	err := a.AssessZoneTransfer(ctx, job.Args.DomainUID)
 	if err != nil {
@@ -111,9 +116,10 @@ func (AssessEmailSecurityArgs) Kind() string { return "assess_email_security" }
 
 type AssessEmailSecurityWorker struct {
 	river.WorkerDefaults[AssessEmailSecurityArgs]
-	Logger  slog.Logger
-	Store   *store.Queries
-	PgxPool *pgxpool.Pool
+	Logger   slog.Logger
+	Store    *store.Queries
+	PgxPool  *pgxpool.Pool
+	Resolver dnsclient.Resolver
 }
 
 func (w *AssessEmailSecurityWorker) Work(
@@ -124,9 +130,10 @@ func (w *AssessEmailSecurityWorker) Work(
 	start := time.Now()
 	w.Logger.InfoContext(ctx, "assess email security started", "domain", job.Args.DomainUID)
 	a := assessor.NewAssessor(assessor.Config{
-		Logger:   &w.Logger,
-		Store:    w.Store,
-		Identity: job.Args.Identity(),
+		Logger:    &w.Logger,
+		Store:     w.Store,
+		DNSClient: w.Resolver,
+		Identity:  job.Args.Identity(),
 	})
 	err := a.AssessEmailSecurity(ctx, int(job.Args.DomainID))
 	if err != nil {

--- a/internal/jobs/enumerate_jobs.go
+++ b/internal/jobs/enumerate_jobs.go
@@ -38,9 +38,10 @@ func (EnumerateSubdomainArgs) InsertOpts() river.InsertOpts {
 
 type EnumerateSubdomainWorker struct {
 	river.WorkerDefaults[EnumerateSubdomainArgs]
-	Logger  slog.Logger
-	Store   *store.Queries
-	PgxPool *pgxpool.Pool
+	Logger   slog.Logger
+	Store    *store.Queries
+	PgxPool  *pgxpool.Pool
+	Resolver dnsclient.Resolver
 }
 
 func (w *EnumerateSubdomainWorker) Timeout(*river.Job[EnumerateSubdomainArgs]) time.Duration {
@@ -52,7 +53,7 @@ func (w *EnumerateSubdomainWorker) Work(
 	job *river.Job[EnumerateSubdomainArgs],
 ) error {
 	ctx = tracing.WithNewTraceID(ctx, true)
-	dnsClient := dnsclient.New()
+	dnsClient := w.Resolver
 	rc := river.ClientFromContext[pgx.Tx](ctx)
 
 	// Drain the discovered host list WITHOUT holding a transaction across the
@@ -166,9 +167,10 @@ func (ResolveDomainArgs) Kind() string { return "resolve_domain" }
 
 type ResolveDomainWorker struct {
 	river.WorkerDefaults[ResolveDomainArgs]
-	Logger  slog.Logger
-	Store   *store.Queries
-	PgxPool *pgxpool.Pool
+	Logger   slog.Logger
+	Store    *store.Queries
+	PgxPool  *pgxpool.Pool
+	Resolver dnsclient.Resolver
 }
 
 // recordResolved syncs every resolved DNS record type for one scan through the
@@ -210,7 +212,7 @@ func (w *ResolveDomainWorker) recordResolved(
 // job args, so the worker never rediscovers or creates the domain.
 func (w *ResolveDomainWorker) Work(ctx context.Context, job *river.Job[ResolveDomainArgs]) error {
 	ctx = tracing.WithNewTraceID(ctx, true)
-	dnsClient := dnsclient.New()
+	dnsClient := w.Resolver
 	fqdn := job.Args.DomainName + "."
 
 	lookup := func(qtype uint16) observer.TypeResult {

--- a/internal/jobs/river.go
+++ b/internal/jobs/river.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 
+	"github.com/danielmichaels/gecko/internal/dnsclient"
 	"github.com/danielmichaels/gecko/internal/store"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -24,6 +25,7 @@ type Config struct {
 	PgxPool     *pgxpool.Pool
 	Logger      *slog.Logger
 	Store       *store.Queries
+	Resolver    dnsclient.Resolver
 	WorkerCount int
 	AddWorkers  bool
 }
@@ -48,6 +50,10 @@ func New(ctx context.Context, cfg Config) (*river.Client[pgx.Tx], error) {
 		)
 	}
 
+	if cfg.Resolver == nil {
+		cfg.Resolver = dnsclient.New()
+	}
+
 	riverConfig := &river.Config{}
 	riverConfig.Hooks = []rivertype.Hook{&CorrelationInsertHook{}}
 	rw := river.NewWorkers()
@@ -55,40 +61,40 @@ func New(ctx context.Context, cfg Config) (*river.Client[pgx.Tx], error) {
 		// scan workers
 		river.AddWorker(
 			rw,
-			&EnumerateSubdomainWorker{Logger: *cfg.Logger, Store: cfg.Store, PgxPool: cfg.PgxPool},
+			&EnumerateSubdomainWorker{Logger: *cfg.Logger, Store: cfg.Store, PgxPool: cfg.PgxPool, Resolver: cfg.Resolver},
 		)
 		river.AddWorker(
 			rw,
-			&ResolveDomainWorker{Logger: *cfg.Logger, Store: cfg.Store, PgxPool: cfg.PgxPool},
+			&ResolveDomainWorker{Logger: *cfg.Logger, Store: cfg.Store, PgxPool: cfg.PgxPool, Resolver: cfg.Resolver},
 		)
 		river.AddWorker(
 			rw,
-			&ScanCertificateWorker{Logger: *cfg.Logger, Store: cfg.Store, PgxPool: cfg.PgxPool},
+			&ScanCertificateWorker{Logger: *cfg.Logger, Store: cfg.Store, PgxPool: cfg.PgxPool, Resolver: cfg.Resolver},
 		)
 		river.AddWorker(
 			rw,
-			&ScanCNAMEWorker{Logger: *cfg.Logger, Store: cfg.Store, PgxPool: cfg.PgxPool},
+			&ScanCNAMEWorker{Logger: *cfg.Logger, Store: cfg.Store, PgxPool: cfg.PgxPool, Resolver: cfg.Resolver},
 		)
 		river.AddWorker(
 			rw,
-			&ScanDNSSECWorker{Logger: *cfg.Logger, Store: cfg.Store, PgxPool: cfg.PgxPool},
+			&ScanDNSSECWorker{Logger: *cfg.Logger, Store: cfg.Store, PgxPool: cfg.PgxPool, Resolver: cfg.Resolver},
 		)
 		river.AddWorker(
 			rw,
-			&ScanZoneTransferWorker{Logger: *cfg.Logger, Store: cfg.Store, PgxPool: cfg.PgxPool},
+			&ScanZoneTransferWorker{Logger: *cfg.Logger, Store: cfg.Store, PgxPool: cfg.PgxPool, Resolver: cfg.Resolver},
 		)
 		// assess workers
 		river.AddWorker(
 			rw,
-			&AssessCNAMEDanglingWorker{Logger: *cfg.Logger, Store: cfg.Store, PgxPool: cfg.PgxPool},
+			&AssessCNAMEDanglingWorker{Logger: *cfg.Logger, Store: cfg.Store, PgxPool: cfg.PgxPool, Resolver: cfg.Resolver},
 		)
 		river.AddWorker(
 			rw,
-			&AssessZoneTransferWorker{Logger: *cfg.Logger, Store: cfg.Store, PgxPool: cfg.PgxPool},
+			&AssessZoneTransferWorker{Logger: *cfg.Logger, Store: cfg.Store, PgxPool: cfg.PgxPool, Resolver: cfg.Resolver},
 		)
 		river.AddWorker(
 			rw,
-			&AssessEmailSecurityWorker{Logger: *cfg.Logger, Store: cfg.Store, PgxPool: cfg.PgxPool},
+			&AssessEmailSecurityWorker{Logger: *cfg.Logger, Store: cfg.Store, PgxPool: cfg.PgxPool, Resolver: cfg.Resolver},
 		)
 		riverConfig.Workers = rw
 		riverConfig.Middleware = []rivertype.Middleware{

--- a/internal/jobs/scan_jobs.go
+++ b/internal/jobs/scan_jobs.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/danielmichaels/gecko/internal/dnsclient"
 	"github.com/danielmichaels/gecko/internal/scanner"
 	"github.com/danielmichaels/gecko/internal/store"
 	"github.com/danielmichaels/gecko/internal/tracing"
@@ -29,9 +30,10 @@ func (ScanCertificateArgs) Kind() string { return "scan_certificate" }
 
 type ScanCertificateWorker struct {
 	river.WorkerDefaults[ScanCertificateArgs]
-	Logger  slog.Logger
-	Store   *store.Queries
-	PgxPool *pgxpool.Pool
+	Logger   slog.Logger
+	Store    *store.Queries
+	PgxPool  *pgxpool.Pool
+	Resolver dnsclient.Resolver
 }
 
 func (w *ScanCertificateWorker) Work(
@@ -41,7 +43,7 @@ func (w *ScanCertificateWorker) Work(
 	ctx = tracing.WithNewTraceID(ctx, true)
 	start := time.Now()
 
-	s := scanner.NewScanner(scanner.Config{Logger: &w.Logger, Store: w.Store})
+	s := scanner.NewScanner(scanner.Config{Logger: &w.Logger, Store: w.Store, Resolver: w.Resolver})
 	result := s.ScanCertificate(job.Args.DomainName)
 	w.Logger.InfoContext(
 		ctx,
@@ -66,16 +68,17 @@ func (ScanCNAMEArgs) Kind() string { return "scan_cname" }
 
 type ScanCNAMEWorker struct {
 	river.WorkerDefaults[ScanCNAMEArgs]
-	Logger  slog.Logger
-	Store   *store.Queries
-	PgxPool *pgxpool.Pool
+	Logger   slog.Logger
+	Store    *store.Queries
+	PgxPool  *pgxpool.Pool
+	Resolver dnsclient.Resolver
 }
 
 func (w *ScanCNAMEWorker) Work(ctx context.Context, job *river.Job[ScanCNAMEArgs]) error {
 	ctx = tracing.WithNewTraceID(ctx, true)
 	start := time.Now()
 
-	s := scanner.NewScanner(scanner.Config{Logger: &w.Logger, Store: w.Store})
+	s := scanner.NewScanner(scanner.Config{Logger: &w.Logger, Store: w.Store, Resolver: w.Resolver})
 	result := s.ScanCNAME(job.Args.DomainName)
 
 	w.Logger.InfoContext(
@@ -107,16 +110,17 @@ func (ScanDNSSECArgs) Kind() string { return "scan_dnssec" }
 
 type ScanDNSSECWorker struct {
 	river.WorkerDefaults[ScanDNSSECArgs]
-	Logger  slog.Logger
-	Store   *store.Queries
-	PgxPool *pgxpool.Pool
+	Logger   slog.Logger
+	Store    *store.Queries
+	PgxPool  *pgxpool.Pool
+	Resolver dnsclient.Resolver
 }
 
 func (w *ScanDNSSECWorker) Work(ctx context.Context, job *river.Job[ScanDNSSECArgs]) error {
 	ctx = tracing.WithNewTraceID(ctx, true)
 	start := time.Now()
 
-	s := scanner.NewScanner(scanner.Config{Logger: &w.Logger, Store: w.Store})
+	s := scanner.NewScanner(scanner.Config{Logger: &w.Logger, Store: w.Store, Resolver: w.Resolver})
 	result := s.ScanDNSSEC(job.Args.DomainName)
 
 	w.Logger.InfoContext(
@@ -146,9 +150,10 @@ func (ScanZoneTransferArgs) Kind() string { return "scan_zone_transfer" }
 
 type ScanZoneTransferWorker struct {
 	river.WorkerDefaults[ScanZoneTransferArgs]
-	Logger  slog.Logger
-	Store   *store.Queries
-	PgxPool *pgxpool.Pool
+	Logger   slog.Logger
+	Store    *store.Queries
+	PgxPool  *pgxpool.Pool
+	Resolver dnsclient.Resolver
 }
 
 func (w *ScanZoneTransferWorker) Work(
@@ -161,6 +166,7 @@ func (w *ScanZoneTransferWorker) Work(
 	s := scanner.NewScanner(scanner.Config{
 		Logger:   &w.Logger,
 		Store:    w.Store,
+		Resolver: w.Resolver,
 		Identity: job.Args.Identity(),
 	})
 	if _, err := s.ScanZoneTransfer(ctx, job.Args.DomainName); err != nil {

--- a/internal/scanner/fake_resolver_test.go
+++ b/internal/scanner/fake_resolver_test.go
@@ -1,0 +1,55 @@
+package scanner
+
+import (
+	"context"
+
+	"github.com/danielmichaels/gecko/internal/dnsclient"
+	"github.com/danielmichaels/gecko/internal/dnsrecords"
+	"github.com/projectdiscovery/subfinder/v2/pkg/resolve"
+)
+
+type fakeResolver struct {
+	cnameReturn []string
+	cnameOK     bool
+	aReturn     []string
+	aOK         bool
+	aaaaReturn  []string
+	aaaaOK      bool
+
+	calledCNAME []string
+	calledA     []string
+	calledAAAA  []string
+}
+
+func (f *fakeResolver) LookupCNAME(target string) ([]string, bool) {
+	f.calledCNAME = append(f.calledCNAME, target)
+	return f.cnameReturn, f.cnameOK
+}
+func (f *fakeResolver) LookupA(target string) ([]string, bool) {
+	f.calledA = append(f.calledA, target)
+	return f.aReturn, f.aOK
+}
+func (f *fakeResolver) LookupAAAA(target string) ([]string, bool) {
+	f.calledAAAA = append(f.calledAAAA, target)
+	return f.aaaaReturn, f.aaaaOK
+}
+func (f *fakeResolver) LookupTXT(string) ([]string, bool) { return nil, false }
+func (f *fakeResolver) LookupDS(string) ([]string, bool)  { return nil, false }
+func (f *fakeResolver) LookupDNSKEYWithRRSIG(string) ([]string, []string, bool) {
+	return nil, nil, false
+}
+func (f *fakeResolver) LookupWithStatus(string, uint16) ([]string, dnsclient.ResolutionStatus) {
+	return nil, dnsclient.ResolutionIndeterminate
+}
+func (f *fakeResolver) IsZoneApex(string) bool      { return false }
+func (f *fakeResolver) ValidateDNSSEC(string) error { return nil }
+func (f *fakeResolver) AttemptZoneTransfer(string) *dnsrecords.ZoneTransferResult {
+	return &dnsrecords.ZoneTransferResult{}
+}
+func (f *fakeResolver) EnumerateWithSubfinderCallback(
+	context.Context, string, int, func(*resolve.HostEntry),
+) error {
+	return nil
+}
+
+var _ dnsclient.Resolver = (*fakeResolver)(nil)

--- a/internal/scanner/scan_cname.go
+++ b/internal/scanner/scan_cname.go
@@ -2,8 +2,6 @@ package scanner
 
 import (
 	"strings"
-
-	"github.com/danielmichaels/gecko/internal/dnsclient"
 )
 
 type CNAMEScanResult struct {
@@ -20,7 +18,7 @@ func (s *Scan) ScanCNAME(domain string) *CNAMEScanResult {
 	res := CNAMEScanResult{
 		Domain: domain,
 	}
-	dc := dnsclient.New()
+	dc := s.resolver
 	cname, ok := dc.LookupCNAME(res.Domain)
 	if !ok {
 		return &res

--- a/internal/scanner/scan_cname_test.go
+++ b/internal/scanner/scan_cname_test.go
@@ -1,0 +1,17 @@
+package scanner
+
+import (
+	"log/slog"
+	"testing"
+)
+
+func TestScanCNAMEUsesInjectedResolver(t *testing.T) {
+	fake := &fakeResolver{cnameReturn: []string{"target.example.com."}, cnameOK: true}
+	s := NewScanner(Config{Logger: slog.Default(), Resolver: fake})
+
+	_ = s.ScanCNAME("app.example.com")
+
+	if len(fake.calledCNAME) == 0 {
+		t.Fatal("ScanCNAME did not route through the injected resolver")
+	}
+}

--- a/internal/scanner/scan_dnssec.go
+++ b/internal/scanner/scan_dnssec.go
@@ -20,24 +20,23 @@ const (
 // todo: a lot of this scanner will need to be moved to an assessor later
 type DNSSECScanner struct {
 	Result *dnsrecords.DNSSECResult
-	Client *dnsclient.DNSClient
+	Client dnsclient.Resolver
 	logger *slog.Logger
 	Domain string
 }
 
-func NewDNSSECScanner(domain string) *DNSSECScanner {
+func NewDNSSECScanner(domain string, client dnsclient.Resolver) *DNSSECScanner {
 	cfg := config.AppConfig()
 	logger, _ := logging.SetupLogger("dns-client", cfg)
 	domain = dns.Fqdn(domain)
 	result := &dnsrecords.DNSSECResult{
 		Domain: domain,
 	}
-	client := dnsclient.New()
 	return &DNSSECScanner{Domain: domain, Client: client, Result: result, logger: logger}
 }
 
 func (s *Scan) ScanDNSSEC(domain string) *dnsrecords.DNSSECResult {
-	ds := NewDNSSECScanner(domain)
+	ds := NewDNSSECScanner(domain, s.resolver)
 
 	// Check if domain is zone apex
 	if !ds.Client.IsZoneApex(domain) {

--- a/internal/scanner/scan_zonetransfer.go
+++ b/internal/scanner/scan_zonetransfer.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/danielmichaels/gecko/internal/dnsclient"
 	"github.com/danielmichaels/gecko/internal/observer"
 	"github.com/danielmichaels/gecko/internal/store"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -35,7 +34,7 @@ func (s *Scan) ScanZoneTransfer(ctx context.Context, domainName string) (string,
 		return "", err
 	}
 
-	client := dnsclient.New()
+	client := s.resolver
 	result := client.AttemptZoneTransfer(domainName)
 	for nameserver, transferType := range result.SuccessfulTransfers {
 		// Convert to assessment-friendly format

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -3,13 +3,15 @@ package scanner
 import (
 	"log/slog"
 
+	"github.com/danielmichaels/gecko/internal/dnsclient"
 	"github.com/danielmichaels/gecko/internal/observer"
 	"github.com/danielmichaels/gecko/internal/store"
 )
 
 type Config struct {
-	Logger *slog.Logger
-	Store  *store.Queries
+	Logger   *slog.Logger
+	Store    *store.Queries
+	Resolver dnsclient.Resolver // nil in unit tests → NewScanner falls back to dnsclient.New()
 	// Identity is the scan identity used to stamp observations. Left zero in unit
 	// tests; emission is skipped then.
 	Identity observer.DomainIdentity
@@ -18,13 +20,19 @@ type Config struct {
 type Scan struct {
 	logger   *slog.Logger
 	store    *store.Queries
+	resolver dnsclient.Resolver
 	identity observer.DomainIdentity
 }
 
 func NewScanner(cfg Config) *Scan {
+	resolver := cfg.Resolver
+	if resolver == nil {
+		resolver = dnsclient.New()
+	}
 	return &Scan{
 		logger:   cfg.Logger,
 		store:    cfg.Store,
+		resolver: resolver,
 		identity: cfg.Identity,
 	}
 }


### PR DESCRIPTION
## Summary

Introduces a `dnsclient.Resolver` interface and injects **one shared resolver** through the job workers into the scanner and assessor, replacing every inline `dnsclient.New()`. This is the structural seam that lets future caching / singleflight / rate-limiting be added as a drop-in `Resolver` implementation with **zero call-site changes**.

Runtime behavior is **identical** after this change — still one plain `*DNSClient`, no caching — but the seam now exists and is tested. Behavior-preserving refactor.

## What changed

- **`dnsclient.Resolver`** — new interface listing the exact method set callers already use; `*DNSClient` satisfies it unchanged (compile-time assertion).
- **Scanner** — `Config`/`Scan` gain an injected `resolver` (nil-fallback to `dnsclient.New()`); `ScanCNAME`, `ScanDNSSEC` (via `NewDNSSECScanner(domain, client)`) and `ScanZoneTransfer` now use it.
- **Assessor** — `DNSClient` field widened from `*DNSClient` to the `Resolver` interface.
- **Jobs** — `jobs.New` creates one resolver per process (it's called once from `cmd.go`) and threads it through all 9 scan/assess/enumerate workers, replacing the two inline `dnsclient.New()` calls in `enumerate_jobs.go`.

## Also fixed

- **`IsZoneApex`** was constructing a fresh default client via `New()` instead of using its receiver, so it ignored the receiver's configured servers (and would bypass any wrapping `Resolver`). Now queries through `c`. Covered by a new offline, deterministic test.