### PR TITLE
Guard domain create/update/delete behind owner/manager role

### DIFF
--- a/internal/server/auth_integration_test.go
+++ b/internal/server/auth_integration_test.go
@@ -22,7 +22,11 @@ import (
 // newAuthAPI builds a real Server over the test container and serves it via httptest
 // so requests exercise the full chi → huma → apiAuth → handler chain. RC is nil; the
 // auth/read/delete paths under test never enqueue a job.
-func newAuthAPI(t *testing.T, pc *testhelpers.PostgresContainer) (*Server, string) {
+func newAuthAPI(
+	t *testing.T,
+	pc *testhelpers.PostgresContainer,
+	sched ...service.DomainScanScheduler,
+) (*Server, string) {
 	t.Helper()
 	cfg := config.AppConfig()
 	cfg.Auth.BcryptCost = 4 // fast hashing for tests
@@ -31,12 +35,16 @@ func newAuthAPI(t *testing.T, pc *testhelpers.PostgresContainer) (*Server, strin
 	if err != nil {
 		t.Fatalf("new provider: %v", err)
 	}
+	var scheduler service.DomainScanScheduler
+	if len(sched) > 0 {
+		scheduler = sched[0]
+	}
 	svc := service.NewWithScheduler(
 		cfg,
 		slog.New(slog.DiscardHandler),
 		pc.Queries,
 		pc.Pool,
-		nil,
+		scheduler,
 		provider,
 	)
 	testCSRFKey := make([]byte, 32) // deterministic zero-filled key for tests

--- a/internal/server/domains_authz_test.go
+++ b/internal/server/domains_authz_test.go
@@ -1,0 +1,92 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/danielmichaels/gecko/internal/jobs"
+	"github.com/danielmichaels/gecko/internal/store"
+	"github.com/danielmichaels/gecko/internal/testhelpers"
+	"github.com/jackc/pgx/v5"
+)
+
+// stubScheduler satisfies service.DomainScanScheduler without a live River queue
+// so owner/manager Create/Update paths can commit during the integration test. It
+// deliberately omits TenantStatsRefresher; the delete path just skips the refresh.
+type stubScheduler struct{}
+
+func (stubScheduler) Schedule(
+	_ context.Context,
+	_ pgx.Tx,
+	_ *store.Queries,
+	_ jobs.DomainScanTarget,
+	_ store.DomainSource,
+) (int64, error) {
+	return 1, nil
+}
+
+// TestAuth_DomainMutationRoleGuard pins the domain mutation boundary: a viewer may
+// read domains but must not create, update, or delete them. Owner and manager keep
+// full access. This is the HTTP-path counterpart to the service-layer guard tests.
+func TestAuth_DomainMutationRoleGuard(t *testing.T) {
+	testhelpers.ParallelDBTest(t)
+	ctx := context.Background()
+	pc, err := testhelpers.CreatePostgresContainer(ctx)
+	if err != nil {
+		t.Fatalf("create container: %v", err)
+	}
+	defer pc.Close(ctx)
+	_, base := newAuthAPI(t, pc, stubScheduler{})
+
+	owner := signup(t, base, "owner@a.com", "supersecret")
+	mgr := inviteAccept(t, base, owner.APIKey, "mgr@a.com", "manager")
+	viewer := inviteAccept(t, base, owner.APIKey, "viewer@a.com", "viewer")
+
+	// Owner creates a domain the viewer will try to mutate.
+	var dom struct {
+		UID string `json:"uid"`
+	}
+	if code := doJSON(t, http.MethodPost, base+"/api/domains", owner.APIKey,
+		map[string]string{"domain": "guarded.example.com"}, &dom); code != http.StatusCreated {
+		t.Fatalf("owner create domain status = %d, want 201", code)
+	}
+
+	// Viewer is forbidden from every mutation.
+	if code := doJSON(t, http.MethodPost, base+"/api/domains", viewer.APIKey,
+		map[string]string{"domain": "viewer-add.example.com"}, nil); code != http.StatusForbidden {
+		t.Errorf("viewer create status = %d, want 403", code)
+	}
+	if code := doJSON(t, http.MethodPut, base+"/api/domains/"+dom.UID, viewer.APIKey,
+		map[string]string{"status": "inactive"}, nil); code != http.StatusForbidden {
+		t.Errorf("viewer update status = %d, want 403", code)
+	}
+	if code := doJSON(t, http.MethodDelete, base+"/api/domains/"+dom.UID, viewer.APIKey,
+		nil, nil); code != http.StatusForbidden {
+		t.Errorf("viewer delete status = %d, want 403", code)
+	}
+
+	// The forbidden create added nothing and the forbidden delete removed nothing.
+	if code := doJSON(t, http.MethodGet, base+"/api/domains/"+dom.UID, owner.APIKey, nil, nil); code != http.StatusOK {
+		t.Errorf("domain after forbidden viewer delete status = %d, want 200", code)
+	}
+
+	// Manager retains full access: update succeeds.
+	if code := doJSON(t, http.MethodPut, base+"/api/domains/"+dom.UID, mgr.APIKey,
+		map[string]string{"status": "active"}, nil); code != http.StatusOK {
+		t.Errorf("manager update status = %d, want 200", code)
+	}
+	// Manager can create.
+	var mgrDom struct {
+		UID string `json:"uid"`
+	}
+	if code := doJSON(t, http.MethodPost, base+"/api/domains", mgr.APIKey,
+		map[string]string{"domain": "mgr-add.example.com"}, &mgrDom); code != http.StatusCreated {
+		t.Errorf("manager create status = %d, want 201", code)
+	}
+	// Owner can delete.
+	if code := doJSON(t, http.MethodDelete, base+"/api/domains/"+dom.UID, owner.APIKey,
+		nil, nil); code != http.StatusNoContent {
+		t.Errorf("owner delete status = %d, want 204", code)
+	}
+}

--- a/internal/server/domains_handlers.go
+++ b/internal/server/domains_handlers.go
@@ -111,10 +111,14 @@ func (app *Server) handleDomainUpdate(
 		Status:     i.Body.Status,
 	})
 	if err != nil {
-		if errors.Is(err, service.ErrNotFound) {
+		switch {
+		case errors.Is(err, service.ErrForbidden):
+			return nil, huma.Error403Forbidden(err.Error())
+		case errors.Is(err, service.ErrNotFound):
 			return nil, huma.Error404NotFound("domain not found")
+		default:
+			return nil, huma.Error500InternalServerError("failed to update domain", err)
 		}
-		return nil, huma.Error500InternalServerError("failed to update domain", err)
 	}
 	return &DomainOutput{Body: dto.DomainToAPI(domain)}, nil
 }
@@ -165,10 +169,14 @@ func (app *Server) handleDomainDelete(
 		return nil, err
 	}
 	if err := app.Svc.DomainsService().Delete(ctx, p, i.ID); err != nil {
-		if errors.Is(err, service.ErrNotFound) {
+		switch {
+		case errors.Is(err, service.ErrForbidden):
+			return nil, huma.Error403Forbidden(err.Error())
+		case errors.Is(err, service.ErrNotFound):
 			return nil, huma.Error404NotFound("domain not found")
+		default:
+			return nil, huma.Error500InternalServerError("failed to delete domain")
 		}
-		return nil, huma.Error500InternalServerError("failed to delete domain")
 	}
 	return nil, nil
 }
@@ -197,10 +205,14 @@ func (app *Server) handleDomainCreate(
 		Status:     i.Body.Status,
 	})
 	if err != nil {
-		if errors.Is(err, service.ErrConflict) {
+		switch {
+		case errors.Is(err, service.ErrForbidden):
+			return nil, huma.Error403Forbidden(err.Error())
+		case errors.Is(err, service.ErrConflict):
 			return nil, huma.Error409Conflict("domain already exists")
+		default:
+			return nil, huma.Error500InternalServerError("failed to create domain", err)
 		}
-		return nil, huma.Error500InternalServerError("failed to create domain", err)
 	}
 	return &DomainOutput{Body: dto.DomainToAPI(domain)}, nil
 }

--- a/internal/service/authz.go
+++ b/internal/service/authz.go
@@ -25,9 +25,20 @@ func requireRole(p *auth.Principal, roles ...string) error {
 	return msgErr(ErrForbidden, "insufficient permissions")
 }
 
+// OwnerOrManager reports whether p may perform owner/manager-gated actions. It is
+// the single source of truth for that boundary: the ownerOrManager guard derives
+// from it (API enforcement) and the UI derives control visibility from it, so the
+// two surfaces cannot drift.
+func OwnerOrManager(p *auth.Principal) bool {
+	return requireRole(p, string(store.UserRoleOwner), string(store.UserRoleManager)) == nil
+}
+
 // ownerOrManager gates an action to owners and managers.
 func ownerOrManager(p *auth.Principal) error {
-	return requireRole(p, string(store.UserRoleOwner), string(store.UserRoleManager))
+	if !OwnerOrManager(p) {
+		return msgErr(ErrForbidden, "insufficient permissions")
+	}
+	return nil
 }
 
 // requireCanGrant returns ErrForbidden unless p may assign targetRole — an actor

--- a/internal/service/domains.go
+++ b/internal/service/domains.go
@@ -223,6 +223,9 @@ func (s *DomainsService) Create(
 	p *auth.Principal,
 	params DomainsCreateParams,
 ) (store.Domains, error) {
+	if err := ownerOrManager(p); err != nil {
+		return store.Domains{}, err
+	}
 	name := dnsrecords.CanonicalizeDomain(params.Domain)
 
 	status := store.DomainStatusActive
@@ -303,6 +306,9 @@ func (s *DomainsService) Update(
 	uid string,
 	params DomainsUpdateParams,
 ) (store.Domains, error) {
+	if err := ownerOrManager(p); err != nil {
+		return store.Domains{}, err
+	}
 	existing, err := s.DB.DomainsGetByID(ctx, store.DomainsGetByIDParams{
 		Uid:      uid,
 		TenantID: pgtype.Int4{Int32: p.TenantID, Valid: true},
@@ -379,6 +385,9 @@ func (s *DomainsService) Delete(
 	p *auth.Principal,
 	uid string,
 ) error {
+	if err := ownerOrManager(p); err != nil {
+		return err
+	}
 	_, err := s.DB.DomainsDeleteByID(ctx, store.DomainsDeleteByIDParams{
 		Uid:      uid,
 		TenantID: pgtype.Int4{Int32: p.TenantID, Valid: true},

--- a/internal/service/domains_test.go
+++ b/internal/service/domains_test.go
@@ -68,6 +68,16 @@ func ownerPrincipal(tenantID int32) *auth.Principal {
 	}
 }
 
+// principalWithRole returns a synthetic principal for the given tenant and role.
+func principalWithRole(tenantID int32, role string) *auth.Principal {
+	return &auth.Principal{
+		UserID:   1,
+		TenantID: tenantID,
+		Role:     role,
+		Email:    "test@example.com",
+	}
+}
+
 func newTestService(
 	pc *testhelpers.PostgresContainer,
 	sched service.DomainScanScheduler,
@@ -440,6 +450,196 @@ func TestDomainsService_DeletionImpact_HappyPath(t *testing.T) {
 	}
 	if count < 1 {
 		t.Errorf("count = %d, want >= 1", count)
+	}
+}
+
+func TestDomainsService_Create_ViewerForbidden(t *testing.T) {
+	testhelpers.ParallelDBTest(t)
+	ctx := context.Background()
+	pc, err := testhelpers.CreatePostgresContainer(ctx)
+	if err != nil {
+		t.Fatalf("create container: %v", err)
+	}
+	defer pc.Close(ctx)
+
+	sched := &fakeScheduler{}
+	svc := newTestService(pc, sched)
+	ds := svc.DomainsService()
+
+	tenantA := createTenant(t, ctx, pc, "a@create-viewer.com")
+
+	_, err = ds.Create(
+		ctx,
+		principalWithRole(tenantA, "viewer"),
+		service.DomainsCreateParams{Domain: "viewer-create.example.com"},
+	)
+	if !errors.Is(err, service.ErrForbidden) {
+		t.Fatalf("viewer Create = %v, want ErrForbidden", err)
+	}
+	if sched.Called() != 0 {
+		t.Errorf("scheduler called %d times on forbidden create, want 0", sched.Called())
+	}
+	// No domain was inserted.
+	result, err := ds.List(ctx, ownerPrincipal(tenantA), service.DomainsListParams{PageSize: 10})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if result.TotalCount != 0 {
+		t.Errorf("domains after forbidden create = %d, want 0", result.TotalCount)
+	}
+}
+
+func TestDomainsService_Create_ManagerSucceeds(t *testing.T) {
+	testhelpers.ParallelDBTest(t)
+	ctx := context.Background()
+	pc, err := testhelpers.CreatePostgresContainer(ctx)
+	if err != nil {
+		t.Fatalf("create container: %v", err)
+	}
+	defer pc.Close(ctx)
+
+	sched := &fakeScheduler{}
+	svc := newTestService(pc, sched)
+	ds := svc.DomainsService()
+
+	tenantA := createTenant(t, ctx, pc, "a@create-manager.com")
+
+	d, err := ds.Create(
+		ctx,
+		principalWithRole(tenantA, "manager"),
+		service.DomainsCreateParams{Domain: "manager-create.example.com"},
+	)
+	if err != nil {
+		t.Fatalf("manager Create: %v", err)
+	}
+	if d.Name != "manager-create.example.com" {
+		t.Errorf("name = %s, want manager-create.example.com", d.Name)
+	}
+	if sched.Called() != 1 {
+		t.Errorf("scheduler called %d times, want 1", sched.Called())
+	}
+}
+
+func TestDomainsService_Update_ViewerForbidden(t *testing.T) {
+	testhelpers.ParallelDBTest(t)
+	ctx := context.Background()
+	pc, err := testhelpers.CreatePostgresContainer(ctx)
+	if err != nil {
+		t.Fatalf("create container: %v", err)
+	}
+	defer pc.Close(ctx)
+
+	sched := &fakeScheduler{}
+	svc := newTestService(pc, sched)
+	ds := svc.DomainsService()
+
+	tenantA := createTenant(t, ctx, pc, "a@update-viewer.com")
+	d := seedDomain(t, ctx, pc, tenantA, "update-viewer.example.com")
+
+	_, err = ds.Update(
+		ctx,
+		principalWithRole(tenantA, "viewer"),
+		d.Uid,
+		service.DomainsUpdateParams{Status: "inactive"},
+	)
+	if !errors.Is(err, service.ErrForbidden) {
+		t.Fatalf("viewer Update = %v, want ErrForbidden", err)
+	}
+	if sched.Called() != 0 {
+		t.Errorf("scheduler called %d times on forbidden update, want 0", sched.Called())
+	}
+	// The domain is unchanged.
+	got, err := ds.Get(ctx, ownerPrincipal(tenantA), d.Uid)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Status != store.DomainStatusActive {
+		t.Errorf("status after forbidden update = %s, want active", got.Status)
+	}
+}
+
+func TestDomainsService_Update_ManagerSucceeds(t *testing.T) {
+	testhelpers.ParallelDBTest(t)
+	ctx := context.Background()
+	pc, err := testhelpers.CreatePostgresContainer(ctx)
+	if err != nil {
+		t.Fatalf("create container: %v", err)
+	}
+	defer pc.Close(ctx)
+
+	sched := &fakeScheduler{}
+	svc := newTestService(pc, sched)
+	ds := svc.DomainsService()
+
+	tenantA := createTenant(t, ctx, pc, "a@update-manager.com")
+	d := seedDomain(t, ctx, pc, tenantA, "update-manager.example.com")
+
+	updated, err := ds.Update(
+		ctx,
+		principalWithRole(tenantA, "manager"),
+		d.Uid,
+		service.DomainsUpdateParams{Status: "inactive"},
+	)
+	if err != nil {
+		t.Fatalf("manager Update: %v", err)
+	}
+	if updated.Status != store.DomainStatusInactive {
+		t.Errorf("status = %s, want inactive", updated.Status)
+	}
+}
+
+func TestDomainsService_Delete_ViewerForbidden(t *testing.T) {
+	testhelpers.ParallelDBTest(t)
+	ctx := context.Background()
+	pc, err := testhelpers.CreatePostgresContainer(ctx)
+	if err != nil {
+		t.Fatalf("create container: %v", err)
+	}
+	defer pc.Close(ctx)
+
+	sched := &fakeScheduler{}
+	svc := newTestService(pc, sched)
+	ds := svc.DomainsService()
+
+	tenantA := createTenant(t, ctx, pc, "a@delete-viewer.com")
+	d := seedDomain(t, ctx, pc, tenantA, "delete-viewer.example.com")
+
+	if err := ds.Delete(ctx, principalWithRole(tenantA, "viewer"), d.Uid); !errors.Is(
+		err,
+		service.ErrForbidden,
+	) {
+		t.Fatalf("viewer Delete = %v, want ErrForbidden", err)
+	}
+	if got := sched.StatsRefreshes(); len(got) != 0 {
+		t.Errorf("stats refreshes on forbidden delete = %v, want none", got)
+	}
+	// The domain still exists.
+	if _, err := ds.Get(ctx, ownerPrincipal(tenantA), d.Uid); err != nil {
+		t.Errorf("domain missing after forbidden delete: %v", err)
+	}
+}
+
+func TestDomainsService_Delete_ManagerSucceeds(t *testing.T) {
+	testhelpers.ParallelDBTest(t)
+	ctx := context.Background()
+	pc, err := testhelpers.CreatePostgresContainer(ctx)
+	if err != nil {
+		t.Fatalf("create container: %v", err)
+	}
+	defer pc.Close(ctx)
+
+	sched := &fakeScheduler{}
+	svc := newTestService(pc, sched)
+	ds := svc.DomainsService()
+
+	tenantA := createTenant(t, ctx, pc, "a@delete-manager.com")
+	d := seedDomain(t, ctx, pc, tenantA, "delete-manager.example.com")
+
+	if err := ds.Delete(ctx, principalWithRole(tenantA, "manager"), d.Uid); err != nil {
+		t.Fatalf("manager Delete: %v", err)
+	}
+	if _, err := ds.Get(ctx, ownerPrincipal(tenantA), d.Uid); !errors.Is(err, service.ErrNotFound) {
+		t.Errorf("domain present after manager delete = %v, want ErrNotFound", err)
 	}
 }
 

--- a/internal/testhelpers/containers.go
+++ b/internal/testhelpers/containers.go
@@ -43,9 +43,9 @@ type PostgresContainer struct {
 }
 
 type sharedTemplateState struct {
-	once sync.Once
-	name string
 	err  error
+	name string
+	once sync.Once
 }
 
 var (
@@ -250,22 +250,26 @@ func templateHash() (string, error) {
 }
 
 func hashEmbeddedMigrations(h hash.Hash) error {
-	return fs.WalkDir(assets.EmbeddedAssets, "migrations", func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() {
+	return fs.WalkDir(
+		assets.EmbeddedAssets,
+		"migrations",
+		func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				return nil
+			}
+			b, err := assets.EmbeddedAssets.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			_, _ = h.Write([]byte(path))
+			_, _ = h.Write([]byte{0})
+			_, _ = h.Write(b)
 			return nil
-		}
-		b, err := assets.EmbeddedAssets.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		_, _ = h.Write([]byte(path))
-		_, _ = h.Write([]byte{0})
-		_, _ = h.Write(b)
-		return nil
-	})
+		},
+	)
 }
 
 func ensureTemplateDatabase(ctx context.Context, adminURL, templateName string) error {
@@ -291,21 +295,14 @@ func ensureTemplateDatabase(ctx context.Context, adminURL, templateName string) 
 			return err
 		}
 		if err := prepareTemplateDatabase(ctx, connStr); err != nil {
-			_, _ = conn.ExecContext(ctx, "DROP DATABASE IF EXISTS "+quoteIdent(templateName)+" WITH (FORCE)")
+			_, _ = conn.ExecContext(
+				ctx,
+				"DROP DATABASE IF EXISTS "+quoteIdent(templateName)+" WITH (FORCE)",
+			)
 			return err
 		}
 		return nil
 	})
-}
-
-func prepareDatabase(
-	ctx context.Context,
-	connStr string,
-) (*pgxpool.Pool, *store.Queries, error) {
-	if err := prepareTemplateDatabase(ctx, connStr); err != nil {
-		return nil, nil, err
-	}
-	return connectDatabase(ctx, connStr)
 }
 
 func prepareTemplateDatabase(ctx context.Context, connStr string) error {

--- a/internal/ui/domain_handlers.go
+++ b/internal/ui/domain_handlers.go
@@ -33,6 +33,11 @@ const maxListDomains = 5000
 // bounds the flat-list DOM, not the underlying fetch.
 const flatPageSize = 50
 
+// permissionDeniedDesc is the toast body shown when a viewer attempts a domain
+// mutation. The controls are hidden for viewers, so this is the backstop for a
+// forged or stale request rather than the primary feedback path.
+const permissionDeniedDesc = "You don't have permission to modify domains"
+
 // handleDomainsGet renders the full domains list page.
 func (h *Handlers) handleDomainsGet(w http.ResponseWriter, r *http.Request) {
 	p, ok := PrincipalFrom(r.Context())
@@ -133,6 +138,7 @@ func (h *Handlers) handleDomainsGet(w http.ResponseWriter, r *http.Request) {
 	if isDatastar {
 		sse := datastar.NewSSE(w, r)
 		csrf := CSRFTokenFrom(r.Context())
+		canManage := service.OwnerOrManager(p)
 		if layout == "flat" {
 			// DOM pagination over the in-memory filtered set: offset 0 replaces the
 			// list, a later offset appends the next page. The offset signal is
@@ -155,7 +161,7 @@ func (h *Handlers) handleDomainsGet(w http.ResponseWriter, r *http.Request) {
 			}
 			if start == 0 || len(page) > 0 {
 				_ = sse.PatchElementTempl(
-					templates.DomainRowsFragment(page, csrf),
+					templates.DomainRowsFragment(page, csrf, canManage),
 					datastar.WithSelectorID("domains-rows"),
 					mode,
 				)
@@ -171,7 +177,7 @@ func (h *Handlers) handleDomainsGet(w http.ResponseWriter, r *http.Request) {
 					Layout:  layout,
 					Domains: rows,
 					Groups:  groups,
-				}, csrf),
+				}, csrf, canManage),
 				datastar.WithSelectorID("domains-rows"),
 				datastar.WithModeInner(),
 			)
@@ -301,6 +307,10 @@ func (h *Handlers) handleDomainCreate(w http.ResponseWriter, r *http.Request) {
 		Domain: form.NewDomain,
 	})
 	if err != nil {
+		if errors.Is(err, service.ErrForbidden) {
+			pushToast(sse, newToast("warn", "NOTICE", "Permission denied", permissionDeniedDesc))
+			return
+		}
 		if errors.Is(err, service.ErrConflict) {
 			pushToast(sse, newToast("warn", "NOTICE", "Domain already tracked", form.NewDomain))
 			return
@@ -327,7 +337,7 @@ func (h *Handlers) handleDomainCreate(w http.ResponseWriter, r *http.Request) {
 			Layout:  "nested",
 			Domains: rows,
 			Groups:  groupDomainsByApex(rows),
-		}, CSRFTokenFrom(r.Context())),
+		}, CSRFTokenFrom(r.Context()), service.OwnerOrManager(p)),
 		datastar.WithSelectorID("domains-rows"),
 		datastar.WithModeInner(),
 	)
@@ -354,6 +364,11 @@ func (h *Handlers) handleDomainDelete(w http.ResponseWriter, r *http.Request) {
 	sse := datastar.NewSSE(w, r)
 
 	err := h.svc.DomainsService().Delete(r.Context(), p, uid)
+	if errors.Is(err, service.ErrForbidden) {
+		// Leave the row in place; the viewer never had permission to remove it.
+		pushToast(sse, newToast("warn", "NOTICE", "Permission denied", permissionDeniedDesc))
+		return
+	}
 	if err != nil && !errors.Is(err, service.ErrNotFound) {
 		h.log.Error("domain delete", "error", err, "uid", uid)
 	}
@@ -613,6 +628,10 @@ func (h *Handlers) handleDomainRescan(w http.ResponseWriter, r *http.Request) {
 	d, err := h.svc.DomainsService().Update(r.Context(), p, uid, service.DomainsUpdateParams{})
 	if err != nil {
 		sse := datastar.NewSSE(w, r)
+		if errors.Is(err, service.ErrForbidden) {
+			pushToast(sse, newToast("warn", "NOTICE", "Permission denied", permissionDeniedDesc))
+			return
+		}
 		if errors.Is(err, service.ErrNotFound) {
 			pushToast(sse, newToast("warn", "NOTICE", "Domain not found", "nothing to rescan"))
 			return
@@ -658,6 +677,12 @@ func (h *Handlers) handleDomainsRescanAll(w http.ResponseWriter, r *http.Request
 	for _, d := range result.Domains {
 		updated, uErr := h.svc.DomainsService().
 			Update(r.Context(), p, d.Uid, service.DomainsUpdateParams{})
+		if errors.Is(uErr, service.ErrForbidden) {
+			// Role is per-principal, not per-domain: the first rejection means every
+			// rescan would be rejected. Stop and surface a single toast.
+			pushToast(sse, newToast("warn", "NOTICE", "Permission denied", permissionDeniedDesc))
+			return
+		}
 		if uErr != nil {
 			h.log.Warn("domains rescan all: update", "error", uErr, "uid", d.Uid)
 			continue
@@ -669,7 +694,7 @@ func (h *Handlers) handleDomainsRescanAll(w http.ResponseWriter, r *http.Request
 		view.FindingsSeverity = "info"
 
 		_ = sse.PatchElementTempl(
-			templates.DomainRow(view, csrfToken),
+			templates.DomainRow(view, csrfToken, service.OwnerOrManager(p)),
 			datastar.WithSelectorID("domain-row-"+d.Uid),
 		)
 	}

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -126,13 +126,14 @@ func (h *Handlers) shell(ctx context.Context, active string) (templates.AppShell
 		tenantName = p.Email
 	}
 	return templates.AppShellProps{
-		TenantName:   tenantName,
-		UserEmail:    p.Email,
-		UserInitials: initials(p.Email),
-		ActiveNav:    active,
-		AppVersion:   version.Get(),
-		ResolverOK:   true,
-		CSRFToken:    CSRFTokenFrom(ctx),
+		TenantName:       tenantName,
+		UserEmail:        p.Email,
+		UserInitials:     initials(p.Email),
+		ActiveNav:        active,
+		AppVersion:       version.Get(),
+		ResolverOK:       true,
+		CSRFToken:        CSRFTokenFrom(ctx),
+		CanManageDomains: service.OwnerOrManager(p),
 	}, nil
 }
 

--- a/internal/ui/templates/domain_detail.templ
+++ b/internal/ui/templates/domain_detail.templ
@@ -19,11 +19,13 @@ templ DomainDetailPage(props DomainDetailPageProps) {
 				</div>
 				<div class="page-head" style="margin-top:-6px">
 					<div class="sub">{ props.Type } · { props.Source } · added { props.Added } · scanned { props.Scanned }</div>
-					<button
-						class="btn"
-						type="button"
-						data-on:click={ postWithCSRF("/app/domains/"+props.UID+"/rescan", props.Shell.CSRFToken) }
-					>⟳ Rescan</button>
+					if props.Shell.CanManageDomains {
+						<button
+							class="btn"
+							type="button"
+							data-on:click={ postWithCSRF("/app/domains/"+props.UID+"/rescan", props.Shell.CSRFToken) }
+						>⟳ Rescan</button>
+					}
 				</div>
 				<div class="tabs">
 					<a data-on:click__prevent="$tab = 'records'" data-class="{'active': $tab === 'records'}">Records</a>

--- a/internal/ui/templates/domain_detail_templ.go
+++ b/internal/ui/templates/domain_detail_templ.go
@@ -200,95 +200,105 @@ func DomainDetailPage(props DomainDetailPageProps) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "</div><button class=\"btn\" type=\"button\" data-on:click=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var15 string
-				templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(postWithCSRF("/app/domains/"+props.UID+"/rescan", props.Shell.CSRFToken))
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 25, Col: 94}
+				if props.Shell.CanManageDomains {
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<button class=\"btn\" type=\"button\" data-on:click=\"")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var15 string
+					templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(postWithCSRF("/app/domains/"+props.UID+"/rescan", props.Shell.CSRFToken))
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 26, Col: 95}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "\">⟳ Rescan</button>")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "\">⟳ Rescan</button></div><div class=\"tabs\"><a data-on:click__prevent=\"$tab = 'records'\" data-class=\"{'active': $tab === 'records'}\">Records</a> <a data-on:click__prevent=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</div><div class=\"tabs\"><a data-on:click__prevent=\"$tab = 'records'\" data-class=\"{'active': $tab === 'records'}\">Records</a> <a data-on:click__prevent=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var16 string
 				templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs("$tab='timeline'; if(!$tlLoaded){$tlLoaded=true; @get('/app/domains/" + props.UID + "/timeline/full')}")
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 31, Col: 134}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 33, Col: 134}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "\" data-class=\"{'active': $tab === 'timeline'}\">Timeline</a> <a data-on:click__prevent=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "\" data-class=\"{'active': $tab === 'timeline'}\">Timeline</a> <a data-on:click__prevent=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var17 string
 				templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs("$tab='findings'; if(!$fnLoaded){$fnLoaded=true; @get('/app/domains/" + props.UID + "/findings')}")
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 35, Col: 129}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 37, Col: 129}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "\" data-class=\"{'active': $tab === 'findings'}\">Findings ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "\" data-class=\"{'active': $tab === 'findings'}\">Findings ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				if props.FindingsCount != "" && props.FindingsCount != "0" {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<span style=\"")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<span style=\"")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var18 string
 					templ_7745c5c3_Var18, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues("color:var(--" + props.FindingsSeverity + ")")
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 40, Col: 66}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 42, Col: 66}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "\">·")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "\">·")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var19 string
 					templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(props.FindingsCount)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 40, Col: 92}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 42, Col: 92}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</span>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "</span>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "</a></div><div class=\"detail-grid\" style=\"display:none\" data-show=\"$tab === 'records'\"><div class=\"panel\" id=\"records-panel\"><div id=\"records-content\" data-on-intersect__once=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "</a></div><div class=\"detail-grid\" style=\"display:none\" data-show=\"$tab === 'records'\"><div class=\"panel\" id=\"records-panel\"><div id=\"records-content\" data-on-intersect__once=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var20 string
 				templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs("@get('/app/domains/" + props.UID + "/records')")
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 48, Col: 81}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 50, Col: 81}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "\"><div class=\"panel-h\">DNS records <span class=\"count\">loading…</span></div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "\"><div class=\"panel-h\">DNS records <span class=\"count\">loading…</span></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -296,20 +306,20 @@ func DomainDetailPage(props DomainDetailPageProps) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "</div></div><div class=\"panel\" id=\"timeline-panel\"><div id=\"timeline-content\" data-on-intersect__once=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "</div></div><div class=\"panel\" id=\"timeline-panel\"><div id=\"timeline-content\" data-on-intersect__once=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var21 string
 				templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs("@get('/app/domains/" + props.UID + "/timeline')")
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 57, Col: 82}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 59, Col: 82}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "\"><div class=\"panel-h\">Change timeline <span class=\"count\">loading…</span></div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "\"><div class=\"panel-h\">Change timeline <span class=\"count\">loading…</span></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -317,38 +327,25 @@ func DomainDetailPage(props DomainDetailPageProps) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "</div></div></div><div style=\"display:none\" data-show=\"$tab === 'timeline'\"><div class=\"panel\" id=\"timeline-full-panel\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "</div></div></div><div style=\"display:none\" data-show=\"$tab === 'timeline'\"><div class=\"panel\" id=\"timeline-full-panel\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				if props.InitialTab == "timeline" {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "<div id=\"timeline-full-content\" data-on-intersect__once=\"")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<div id=\"timeline-full-content\" data-on-intersect__once=\"")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var22 string
 					templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(timelineFullLoad(props.UID, props.InitialScan))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 69, Col: 80}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 71, Col: 80}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "\"><div class=\"panel-h\">Change timeline <span class=\"count\">loading…</span></div>")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					templ_7745c5c3_Err = timelineSkeleton().Render(ctx, templ_7745c5c3_Buffer)
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "</div>")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-				} else {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "<div id=\"timeline-full-content\"><div class=\"panel-h\">Change timeline <span class=\"count\">loading…</span></div>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "\"><div class=\"panel-h\">Change timeline <span class=\"count\">loading…</span></div>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -360,8 +357,21 @@ func DomainDetailPage(props DomainDetailPageProps) templ.Component {
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
+				} else {
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "<div id=\"timeline-full-content\"><div class=\"panel-h\">Change timeline <span class=\"count\">loading…</span></div>")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = timelineSkeleton().Render(ctx, templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "</div>")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "</div></div><div style=\"display:none\" data-show=\"$tab === 'findings'\"><div id=\"findings-content\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</div></div><div style=\"display:none\" data-show=\"$tab === 'findings'\"><div id=\"findings-content\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -369,7 +379,7 @@ func DomainDetailPage(props DomainDetailPageProps) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "</div></div></div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "</div></div></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -410,7 +420,7 @@ func recordsSkeleton() templ.Component {
 			templ_7745c5c3_Var23 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "<div style=\"padding:16px\"><div style=\"height:16px;background:var(--panel-2);border-radius:4px;margin-bottom:10px;width:80%\"></div><div style=\"height:16px;background:var(--panel-2);border-radius:4px;margin-bottom:10px;width:60%\"></div><div style=\"height:16px;background:var(--panel-2);border-radius:4px;margin-bottom:10px;width:70%\"></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "<div style=\"padding:16px\"><div style=\"height:16px;background:var(--panel-2);border-radius:4px;margin-bottom:10px;width:80%\"></div><div style=\"height:16px;background:var(--panel-2);border-radius:4px;margin-bottom:10px;width:60%\"></div><div style=\"height:16px;background:var(--panel-2);border-radius:4px;margin-bottom:10px;width:70%\"></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -439,7 +449,7 @@ func timelineSkeleton() templ.Component {
 			templ_7745c5c3_Var24 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "<div style=\"padding:16px\"><div style=\"height:16px;background:var(--panel-2);border-radius:4px;margin-bottom:10px;width:75%\"></div><div style=\"height:16px;background:var(--panel-2);border-radius:4px;margin-bottom:10px;width:55%\"></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "<div style=\"padding:16px\"><div style=\"height:16px;background:var(--panel-2);border-radius:4px;margin-bottom:10px;width:75%\"></div><div style=\"height:16px;background:var(--panel-2);border-radius:4px;margin-bottom:10px;width:55%\"></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -468,122 +478,122 @@ func RecordsTable(v RecordsView) templ.Component {
 			templ_7745c5c3_Var25 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "<div class=\"panel-h\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "<div class=\"panel-h\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var26 string
 		templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(v.Title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 108, Col: 31}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 110, Col: 31}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, " <span class=\"count\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, " <span class=\"count\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var27 string
 		templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(v.Count)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 108, Col: 63}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 110, Col: 63}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "</span></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "</span></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		for _, r := range v.Rows {
 			if r.Flagged {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "<div class=\"rec flag\"><span class=\"type\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "<div class=\"rec flag\"><span class=\"type\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var28 string
 				templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(r.Type)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 112, Col: 31}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 114, Col: 31}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "</span> <span class=\"val\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "</span> <span class=\"val\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var29 string
 				templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinStringErrs(r.Value)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 113, Col: 31}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 115, Col: 31}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var29))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "</span> <span class=\"ttl\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "</span> <span class=\"ttl\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var30 string
 				templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs(r.TTL)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 114, Col: 29}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 116, Col: 29}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "</span></div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "</span></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			} else {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "<div class=\"rec\"><span class=\"type\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "<div class=\"rec\"><span class=\"type\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var31 string
 				templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs(r.Type)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 118, Col: 31}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 120, Col: 31}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "</span> <span class=\"val\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "</span> <span class=\"val\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var32 string
 				templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(r.Value)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 119, Col: 31}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 121, Col: 31}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "</span> <span class=\"ttl\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "</span> <span class=\"ttl\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var33 string
 				templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(r.TTL)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 120, Col: 29}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 122, Col: 29}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "</span></div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "</span></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -614,7 +624,7 @@ func Timeline(v TimelineView) templ.Component {
 			templ_7745c5c3_Var34 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "<div class=\"panel-h\">Change timeline <span class=\"count\">grouped by scan</span></div><div class=\"tl\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "<div class=\"panel-h\">Change timeline <span class=\"count\">grouped by scan</span></div><div class=\"tl\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -624,7 +634,7 @@ func Timeline(v TimelineView) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "<div class=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "<div class=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -637,38 +647,38 @@ func Timeline(v TimelineView) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "\"><span class=\"dot\"></span><div class=\"when\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "\"><span class=\"dot\"></span><div class=\"when\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var37 string
 			templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.JoinStringErrs(item.When)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 132, Col: 33}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 134, Col: 33}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var37))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "</div><div class=\"what\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "</div><div class=\"what\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var38 string
 			templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.JoinStringErrs(item.What)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 133, Col: 33}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 135, Col: 33}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var38))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "</div></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "</div></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -699,30 +709,30 @@ func TimelineFull(v TimelineFullView) templ.Component {
 			templ_7745c5c3_Var39 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "<div class=\"panel-h\">Change timeline <span class=\"count\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "<div class=\"panel-h\">Change timeline <span class=\"count\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var40 string
 		templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d scans · %d changes", v.ScanCount, v.ChangeCount))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 143, Col: 105}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 145, Col: 105}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var40))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "</span></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "</span></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if len(v.Groups) == 0 {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "<div class=\"trow-empty\">no changes recorded yet</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "<div class=\"trow-empty\">no changes recorded yet</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "<div class=\"tlx\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "<div class=\"tlx\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -732,7 +742,7 @@ func TimelineFull(v TimelineFullView) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "<div class=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, "<div class=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -745,59 +755,59 @@ func TimelineFull(v TimelineFullView) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "\"><div class=\"scan-hd\"><span class=\"m\"></span><div><div class=\"nm\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, "\"><div class=\"scan-hd\"><span class=\"m\"></span><div><div class=\"nm\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var43 string
 				templ_7745c5c3_Var43, templ_7745c5c3_Err = templ.JoinStringErrs(g.ScanID)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 154, Col: 33}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 156, Col: 33}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var43))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, "</div><div class=\"mt\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, "</div><div class=\"mt\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var44 string
 				templ_7745c5c3_Var44, templ_7745c5c3_Err = templ.JoinStringErrs(g.When)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 155, Col: 31}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 157, Col: 31}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var44))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, " · ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 60, " · ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var45 string
 				templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.JoinStringErrs(g.Meta)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 155, Col: 45}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 157, Col: 45}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var45))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, "</div></div><span class=\"cb\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 61, "</div></div><span class=\"cb\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var46 string
 				templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d changes", g.ChangeCount))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 157, Col: 65}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 159, Col: 65}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var46))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 60, "</span></div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, "</span></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -807,7 +817,7 @@ func TimelineFull(v TimelineFullView) templ.Component {
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 61, "<div class=\"")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 63, "<div class=\"")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -820,56 +830,56 @@ func TimelineFull(v TimelineFullView) templ.Component {
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, "\"><span class=\"op\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 64, "\"><span class=\"op\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var49 string
 					templ_7745c5c3_Var49, templ_7745c5c3_Err = templ.JoinStringErrs(ch.Op)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 161, Col: 31}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 163, Col: 31}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var49))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 63, "</span> <span class=\"ent\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 65, "</span> <span class=\"ent\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var50 string
 					templ_7745c5c3_Var50, templ_7745c5c3_Err = templ.JoinStringErrs(ch.Entity)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 162, Col: 36}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 164, Col: 36}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var50))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 64, "</span> <span class=\"cv\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 66, "</span> <span class=\"cv\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var51 string
 					templ_7745c5c3_Var51, templ_7745c5c3_Err = templ.JoinStringErrs(ch.Value)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 163, Col: 34}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 165, Col: 34}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var51))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 65, "</span></div>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 67, "</span></div>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 66, "</div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 68, "</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 67, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 69, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -902,86 +912,86 @@ func FindingsPanel(v FindingsView) templ.Component {
 		}
 		ctx = templ.ClearChildren(ctx)
 		if v.TotalCount == 0 {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 68, "<div class=\"trow-empty\">no findings yet — run a scan to assess this domain</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 70, "<div class=\"trow-empty\">no findings yet — run a scan to assess this domain</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 69, "<div class=\"f-assessed\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 71, "<div class=\"f-assessed\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var53 string
 			templ_7745c5c3_Var53, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d checks · %d critical · %d warnings · %d healthy", v.TotalCount, v.CriticalCount, v.WarningCount, v.HealthyCount))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 179, Col: 136}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 181, Col: 136}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var53))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 70, "</div><div class=\"find-sum\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 72, "</div><div class=\"find-sum\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if v.CriticalCount > 0 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 71, "<div class=\"s c\"><i></i> <b>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 73, "<div class=\"s c\"><i></i> <b>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var54 string
 				templ_7745c5c3_Var54, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", v.CriticalCount))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 183, Col: 68}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 185, Col: 68}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var54))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 72, "</b> critical</div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 74, "</b> critical</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
 			if v.WarningCount > 0 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 73, "<div class=\"s w\"><i></i> <b>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 75, "<div class=\"s w\"><i></i> <b>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var55 string
 				templ_7745c5c3_Var55, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", v.WarningCount))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 186, Col: 67}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 188, Col: 67}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var55))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 74, "</b> warnings</div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 76, "</b> warnings</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
 			if v.HealthyCount > 0 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 75, "<div class=\"s o\"><i></i> <b>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 77, "<div class=\"s o\"><i></i> <b>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var56 string
 				templ_7745c5c3_Var56, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", v.HealthyCount))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 189, Col: 67}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 191, Col: 67}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var56))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 76, "</b> healthy</div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 78, "</b> healthy</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 77, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 79, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -991,7 +1001,7 @@ func FindingsPanel(v FindingsView) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 78, "<div class=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 80, "<div class=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -1004,20 +1014,20 @@ func FindingsPanel(v FindingsView) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 79, "\"><div class=\"f-ico\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 81, "\"><div class=\"f-ico\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var59 string
 				templ_7745c5c3_Var59, templ_7745c5c3_Err = templ.JoinStringErrs(f.Icon)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 194, Col: 31}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 196, Col: 31}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var59))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 80, "</div><div><div class=\"f-top\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 82, "</div><div><div class=\"f-top\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -1026,7 +1036,7 @@ func FindingsPanel(v FindingsView) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 81, "<span class=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 83, "<span class=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -1039,85 +1049,66 @@ func FindingsPanel(v FindingsView) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 82, "\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 84, "\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var62 string
 				templ_7745c5c3_Var62, templ_7745c5c3_Err = templ.JoinStringErrs(f.Severity)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 197, Col: 54}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 199, Col: 54}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var62))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 83, "</span><h4>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 85, "</span><h4>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var63 string
 				templ_7745c5c3_Var63, templ_7745c5c3_Err = templ.JoinStringErrs(f.Title)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 198, Col: 19}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 200, Col: 19}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var63))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 84, "</h4></div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 86, "</h4></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				if f.Description != "" {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 85, "<p>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 87, "<p>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var64 string
 					templ_7745c5c3_Var64, templ_7745c5c3_Err = templ.JoinStringErrs(f.Description)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 201, Col: 24}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 203, Col: 24}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var64))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 86, "</p>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 88, "</p>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				}
 				if f.Evidence != "" {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 87, "<div class=\"f-ev\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 89, "<div class=\"f-ev\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var65 string
 					templ_7745c5c3_Var65, templ_7745c5c3_Err = templ.JoinStringErrs(f.Evidence)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 204, Col: 36}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 206, Col: 36}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var65))
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 88, "</div>")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-				}
-				if f.FixHint != "" {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 89, "<div class=\"f-fix\">→ <b>Fix:</b> ")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					var templ_7745c5c3_Var66 string
-					templ_7745c5c3_Var66, templ_7745c5c3_Err = templ.JoinStringErrs(f.FixHint)
-					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 207, Col: 52}
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var66))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -1126,7 +1117,26 @@ func FindingsPanel(v FindingsView) templ.Component {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 91, "</div></div>")
+				if f.FixHint != "" {
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 91, "<div class=\"f-fix\">→ <b>Fix:</b> ")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var66 string
+					templ_7745c5c3_Var66, templ_7745c5c3_Err = templ.JoinStringErrs(f.FixHint)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 209, Col: 52}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var66))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 92, "</div>")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 93, "</div></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}

--- a/internal/ui/templates/domains.templ
+++ b/internal/ui/templates/domains.templ
@@ -11,11 +11,13 @@ templ DomainsPage(props DomainsPageProps) {
 							{ props.Stats.Tracked } tracked · { props.Stats.Critical } critical · { props.Stats.Warnings } warnings
 						</div>
 					</div>
-					<button
-						class="btn-ghost btn"
-						type="button"
-						data-on:click={ postWithConfirm("Rescan all tracked domains?", "/app/domains/rescan", props.Shell.CSRFToken) }
-					>⟳ Rescan all</button>
+					if props.Shell.CanManageDomains {
+						<button
+							class="btn-ghost btn"
+							type="button"
+							data-on:click={ postWithConfirm("Rescan all tracked domains?", "/app/domains/rescan", props.Shell.CSRFToken) }
+						>⟳ Rescan all</button>
+					}
 				</div>
 				<div class="stats">
 					<div class="stat">
@@ -65,11 +67,13 @@ templ DomainsPage(props DomainsPageProps) {
 							data-on:click="$layout = 'flat'; $offset = 0; @get('/app/domains')"
 						><span class="gly">≡</span> Flat</button>
 					</div>
-					<button
-						class="btn btn-add"
-						type="button"
-						data-on:click="$drawerOpen = true"
-					>+ Add domain</button>
+					if props.Shell.CanManageDomains {
+						<button
+							class="btn btn-add"
+							type="button"
+							data-on:click="$drawerOpen = true"
+						>+ Add domain</button>
+					}
 				</div>
 				<div class="result-meta" id="result-meta">{ props.Stats.Tracked } domains</div>
 				<div class="domain-table">
@@ -81,35 +85,37 @@ templ DomainsPage(props DomainsPageProps) {
 						<span></span>
 					</div>
 					<div id="domains-rows">
-						@DomainTableBody(props, props.Shell.CSRFToken)
+						@DomainTableBody(props, props.Shell.CSRFToken, props.Shell.CanManageDomains)
 					</div>
 				</div>
 				@DomainsLoadMore(false)
-				<div class="scrim" data-class="{'open': $drawerOpen}" data-on:click="$drawerOpen = false"></div>
-				<aside class="drawer" data-class="{'open': $drawerOpen}">
-					<div class="drawer-h">
-						<h3>Add domain</h3>
-						<span class="x" data-on:click="$drawerOpen = false">✕</span>
-					</div>
-					<div class="drawer-b">
-						<div>
-							<span class="lbl">Domain</span>
-							<div class="in">
-								<span class="lead">domain ⟶</span>
-								<input placeholder="example.com" data-bind="newDomain"/>
-							</div>
-							<p class="hint">Enter an apex or subdomain. Gecko resolves its DNS facts and assesses them on the next scan.</p>
+				if props.Shell.CanManageDomains {
+					<div class="scrim" data-class="{'open': $drawerOpen}" data-on:click="$drawerOpen = false"></div>
+					<aside class="drawer" data-class="{'open': $drawerOpen}">
+						<div class="drawer-h">
+							<h3>Add domain</h3>
+							<span class="x" data-on:click="$drawerOpen = false">✕</span>
 						</div>
-					</div>
-					<div class="drawer-f">
-						<button class="btn-ghost btn" type="button" data-on:click="$drawerOpen = false">Cancel</button>
-						<button
-							class="btn"
-							type="button"
-							data-on:click={ postWithCSRF("/app/domains", props.Shell.CSRFToken) }
-						>+ Add domain</button>
-					</div>
-				</aside>
+						<div class="drawer-b">
+							<div>
+								<span class="lbl">Domain</span>
+								<div class="in">
+									<span class="lead">domain ⟶</span>
+									<input placeholder="example.com" data-bind="newDomain"/>
+								</div>
+								<p class="hint">Enter an apex or subdomain. Gecko resolves its DNS facts and assesses them on the next scan.</p>
+							</div>
+						</div>
+						<div class="drawer-f">
+							<button class="btn-ghost btn" type="button" data-on:click="$drawerOpen = false">Cancel</button>
+							<button
+								class="btn"
+								type="button"
+								data-on:click={ postWithCSRF("/app/domains", props.Shell.CSRFToken) }
+							>+ Add domain</button>
+						</div>
+					</aside>
+				}
 			</div>
 		}
 	}
@@ -131,14 +137,14 @@ templ DomainsLoadMore(show bool) {
 // layouts. Flat reuses today's exact per-domain rows; nested renders apex groups
 // with collapse toggles. The layout choice arrives as a server-rendered prop
 // (driven by the $layout signal sent to the handler).
-templ DomainTableBody(props DomainsPageProps, csrfToken string) {
+templ DomainTableBody(props DomainsPageProps, csrfToken string, canManage bool) {
 	if props.Layout == "flat" {
-		@DomainRowsFragment(props.Domains, csrfToken)
+		@DomainRowsFragment(props.Domains, csrfToken, canManage)
 	} else if len(props.Groups) == 0 {
 		<div class="trow-empty">no domains match your search</div>
 	} else {
 		for _, g := range props.Groups {
-			@DomainGroupRow(g, csrfToken)
+			@DomainGroupRow(g, csrfToken, canManage)
 		}
 	}
 }
@@ -146,7 +152,7 @@ templ DomainTableBody(props DomainsPageProps, csrfToken string) {
 // DomainGroupRow renders one apex group: the apex header row (whose click
 // toggles the group via the $collapsed array signal) followed by its child rows
 // as grid siblings so column alignment is preserved.
-templ DomainGroupRow(g DomainGroupView, csrfToken string) {
+templ DomainGroupRow(g DomainGroupView, csrfToken string, canManage bool) {
 	<div
 		class={ "trow", "apex", g.RollupSeverity }
 		data-class={ collapsedClass(g.Apex) }
@@ -183,14 +189,14 @@ templ DomainGroupRow(g DomainGroupView, csrfToken string) {
 		<span class="chev">→</span>
 	</div>
 	for i, c := range g.Children {
-		@DomainChildRow(c, g.Apex, i == len(g.Children)-1, csrfToken)
+		@DomainChildRow(c, g.Apex, i == len(g.Children)-1, csrfToken, canManage)
 	}
 }
 
 // DomainChildRow renders a subdomain under its apex: indented with a tree
 // connector, showing only the label in bold against the dimmed apex. Hidden when
 // the parent group is collapsed (data-show keyed on the same $collapsed signal).
-templ DomainChildRow(c DomainRowView, apex string, last bool, csrfToken string) {
+templ DomainChildRow(c DomainRowView, apex string, last bool, csrfToken string, canManage bool) {
 	<div
 		class={ "trow", "child", c.FindingsSeverity, templ.KV("last", last) }
 		id={ "domain-row-" + c.UID }
@@ -213,11 +219,13 @@ templ DomainChildRow(c DomainRowView, apex string, last bool, csrfToken string) 
 			<span class="cell-mono">{ c.LastScan }</span>
 		</a>
 		<span class="chev" style="display:flex;align-items:center;gap:8px;justify-content:flex-end">
-			<button
-				type="button"
-				style="background:transparent;border:0;color:var(--txt-faint);cursor:pointer;font-size:13px;padding:2px 6px;border-radius:4px"
-				data-on:click={ deleteRowWithConfirm("/app/domains/"+c.UID, csrfToken) }
-			>✕</button>
+			if canManage {
+				<button
+					type="button"
+					style="background:transparent;border:0;color:var(--txt-faint);cursor:pointer;font-size:13px;padding:2px 6px;border-radius:4px"
+					data-on:click={ deleteRowWithConfirm("/app/domains/"+c.UID, csrfToken) }
+				>✕</button>
+			}
 			→
 		</span>
 	</div>
@@ -234,17 +242,17 @@ templ RollupDots(severities []string) {
 
 // DomainRowsFragment renders the inner content of #domains-rows: every domain
 // row, or an empty-state line. Shared by the full page and the search SSE patch.
-templ DomainRowsFragment(domains []DomainRowView, csrfToken string) {
+templ DomainRowsFragment(domains []DomainRowView, csrfToken string, canManage bool) {
 	if len(domains) == 0 {
 		<div class="trow-empty">no domains match your search</div>
 	} else {
 		for _, d := range domains {
-			@DomainRow(d, csrfToken)
+			@DomainRow(d, csrfToken, canManage)
 		}
 	}
 }
 
-templ DomainRow(d DomainRowView, csrfToken string) {
+templ DomainRow(d DomainRowView, csrfToken string, canManage bool) {
 	<div
 		class={ "trow", d.Severity }
 		id={ "domain-row-" + d.UID }
@@ -266,11 +274,13 @@ templ DomainRow(d DomainRowView, csrfToken string) {
 			<span class="cell-mono">{ d.LastScan }</span>
 		</a>
 		<span class="chev" style="display:flex;align-items:center;gap:8px;justify-content:flex-end">
-			<button
-				type="button"
-				style="background:transparent;border:0;color:var(--txt-faint);cursor:pointer;font-size:13px;padding:2px 6px;border-radius:4px"
-				data-on:click={ deleteRowWithConfirm("/app/domains/"+d.UID, csrfToken) }
-			>✕</button>
+			if canManage {
+				<button
+					type="button"
+					style="background:transparent;border:0;color:var(--txt-faint);cursor:pointer;font-size:13px;padding:2px 6px;border-radius:4px"
+					data-on:click={ deleteRowWithConfirm("/app/domains/"+d.UID, csrfToken) }
+				>✕</button>
+			}
 			→
 		</span>
 	</div>

--- a/internal/ui/templates/domains_templ.go
+++ b/internal/ui/templates/domains_templ.go
@@ -92,129 +92,149 @@ func DomainsPage(props DomainsPageProps) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, " warnings</div></div><button class=\"btn-ghost btn\" type=\"button\" data-on:click=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, " warnings</div></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var7 string
-				templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(postWithConfirm("Rescan all tracked domains?", "/app/domains/rescan", props.Shell.CSRFToken))
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 17, Col: 114}
+				if props.Shell.CanManageDomains {
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<button class=\"btn-ghost btn\" type=\"button\" data-on:click=\"")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var7 string
+					templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(postWithConfirm("Rescan all tracked domains?", "/app/domains/rescan", props.Shell.CSRFToken))
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 18, Col: 115}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "\">⟳ Rescan all</button>")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\">⟳ Rescan all</button></div><div class=\"stats\"><div class=\"stat\"><div class=\"k\">Tracked</div><div class=\"v\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</div><div class=\"stats\"><div class=\"stat\"><div class=\"k\">Tracked</div><div class=\"v\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var8 string
 				templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(props.Stats.Tracked)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 23, Col: 42}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 25, Col: 42}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div></div><div class=\"stat crit\"><div class=\"k\">Critical</div><div class=\"v\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div></div><div class=\"stat crit\"><div class=\"k\">Critical</div><div class=\"v\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var9 string
 				templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(props.Stats.Critical)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 27, Col: 43}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 29, Col: 43}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</div></div><div class=\"stat warn\"><div class=\"k\">Warnings</div><div class=\"v\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</div></div><div class=\"stat warn\"><div class=\"k\">Warnings</div><div class=\"v\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var10 string
 				templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(props.Stats.Warnings)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 31, Col: 43}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 33, Col: 43}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div></div><div class=\"stat\"><div class=\"k\">Records</div><div class=\"v\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</div></div><div class=\"stat\"><div class=\"k\">Records</div><div class=\"v\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var11 string
 				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(props.Stats.Records)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 35, Col: 42}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 37, Col: 42}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, " <small>total</small></div></div></div><div class=\"toolbar\"><div class=\"search\"><span class=\"mag\">⌕</span> <input placeholder=\"Search domains…\" data-bind=\"q\" data-on:input__debounce.300ms=\"$offset = 0; @get('/app/domains')\"> <span class=\"kbd\">/</span></div><div class=\"tld-filter\"><select data-bind=\"tld\" data-on:change=\"$offset = 0; @get('/app/domains')\"><option value=\"\">All top-level</option> ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, " <small>total</small></div></div></div><div class=\"toolbar\"><div class=\"search\"><span class=\"mag\">⌕</span> <input placeholder=\"Search domains…\" data-bind=\"q\" data-on:input__debounce.300ms=\"$offset = 0; @get('/app/domains')\"> <span class=\"kbd\">/</span></div><div class=\"tld-filter\"><select data-bind=\"tld\" data-on:change=\"$offset = 0; @get('/app/domains')\"><option value=\"\">All top-level</option> ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				for _, t := range props.TLDOptions {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<option value=\"")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<option value=\"")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var12 string
 					templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(t)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 52, Col: 25}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 54, Col: 25}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var13 string
 					templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(t)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 52, Col: 31}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 54, Col: 31}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</option>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</option>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "</select></div><div class=\"seg\"><button type=\"button\" data-class=\"{'on': $layout === 'nested'}\" data-on:click=\"$layout = 'nested'; $offset = 0; @get('/app/domains')\"><span class=\"gly\">⊟</span> Nested</button> <button type=\"button\" data-class=\"{'on': $layout === 'flat'}\" data-on:click=\"$layout = 'flat'; $offset = 0; @get('/app/domains')\"><span class=\"gly\">≡</span> Flat</button></div><button class=\"btn btn-add\" type=\"button\" data-on:click=\"$drawerOpen = true\">+ Add domain</button></div><div class=\"result-meta\" id=\"result-meta\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "</select></div><div class=\"seg\"><button type=\"button\" data-class=\"{'on': $layout === 'nested'}\" data-on:click=\"$layout = 'nested'; $offset = 0; @get('/app/domains')\"><span class=\"gly\">⊟</span> Nested</button> <button type=\"button\" data-class=\"{'on': $layout === 'flat'}\" data-on:click=\"$layout = 'flat'; $offset = 0; @get('/app/domains')\"><span class=\"gly\">≡</span> Flat</button></div>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				if props.Shell.CanManageDomains {
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<button class=\"btn btn-add\" type=\"button\" data-on:click=\"$drawerOpen = true\">+ Add domain</button>")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "</div><div class=\"result-meta\" id=\"result-meta\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var14 string
 				templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(props.Stats.Tracked)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 74, Col: 67}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 78, Col: 67}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, " domains</div><div class=\"domain-table\"><div class=\"thead\"><span>Domain</span> <span>Records</span> <span>Findings</span> <span>Last scan</span> <span></span></div><div id=\"domains-rows\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, " domains</div><div class=\"domain-table\"><div class=\"thead\"><span>Domain</span> <span>Records</span> <span>Findings</span> <span>Last scan</span> <span></span></div><div id=\"domains-rows\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = DomainTableBody(props, props.Shell.CSRFToken).Render(ctx, templ_7745c5c3_Buffer)
+				templ_7745c5c3_Err = DomainTableBody(props, props.Shell.CSRFToken, props.Shell.CanManageDomains).Render(ctx, templ_7745c5c3_Buffer)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "</div></div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</div></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -222,20 +242,26 @@ func DomainsPage(props DomainsPageProps) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<div class=\"scrim\" data-class=\"{'open': $drawerOpen}\" data-on:click=\"$drawerOpen = false\"></div><aside class=\"drawer\" data-class=\"{'open': $drawerOpen}\"><div class=\"drawer-h\"><h3>Add domain</h3><span class=\"x\" data-on:click=\"$drawerOpen = false\">✕</span></div><div class=\"drawer-b\"><div><span class=\"lbl\">Domain</span><div class=\"in\"><span class=\"lead\">domain ⟶</span> <input placeholder=\"example.com\" data-bind=\"newDomain\"></div><p class=\"hint\">Enter an apex or subdomain. Gecko resolves its DNS facts and assesses them on the next scan.</p></div></div><div class=\"drawer-f\"><button class=\"btn-ghost btn\" type=\"button\" data-on:click=\"$drawerOpen = false\">Cancel</button> <button class=\"btn\" type=\"button\" data-on:click=\"")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
+				if props.Shell.CanManageDomains {
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<div class=\"scrim\" data-class=\"{'open': $drawerOpen}\" data-on:click=\"$drawerOpen = false\"></div><aside class=\"drawer\" data-class=\"{'open': $drawerOpen}\"><div class=\"drawer-h\"><h3>Add domain</h3><span class=\"x\" data-on:click=\"$drawerOpen = false\">✕</span></div><div class=\"drawer-b\"><div><span class=\"lbl\">Domain</span><div class=\"in\"><span class=\"lead\">domain ⟶</span> <input placeholder=\"example.com\" data-bind=\"newDomain\"></div><p class=\"hint\">Enter an apex or subdomain. Gecko resolves its DNS facts and assesses them on the next scan.</p></div></div><div class=\"drawer-f\"><button class=\"btn-ghost btn\" type=\"button\" data-on:click=\"$drawerOpen = false\">Cancel</button> <button class=\"btn\" type=\"button\" data-on:click=\"")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var15 string
+					templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(postWithCSRF("/app/domains", props.Shell.CSRFToken))
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 114, Col: 75}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "\">+ Add domain</button></div></aside>")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
 				}
-				var templ_7745c5c3_Var15 string
-				templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(postWithCSRF("/app/domains", props.Shell.CSRFToken))
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 109, Col: 74}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "\">+ Add domain</button></div></aside></div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -280,17 +306,17 @@ func DomainsLoadMore(show bool) templ.Component {
 			templ_7745c5c3_Var16 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<div id=\"domains-more\" class=\"load-more\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "<div id=\"domains-more\" class=\"load-more\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if show {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<button type=\"button\" class=\"btn-ghost btn\" data-on:click=\"@get('/app/domains')\">↓ Load more</button>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "<button type=\"button\" class=\"btn-ghost btn\" data-on:click=\"@get('/app/domains')\">↓ Load more</button>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -302,7 +328,7 @@ func DomainsLoadMore(show bool) templ.Component {
 // layouts. Flat reuses today's exact per-domain rows; nested renders apex groups
 // with collapse toggles. The layout choice arrives as a server-rendered prop
 // (driven by the $layout signal sent to the handler).
-func DomainTableBody(props DomainsPageProps, csrfToken string) templ.Component {
+func DomainTableBody(props DomainsPageProps, csrfToken string, canManage bool) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -324,18 +350,18 @@ func DomainTableBody(props DomainsPageProps, csrfToken string) templ.Component {
 		}
 		ctx = templ.ClearChildren(ctx)
 		if props.Layout == "flat" {
-			templ_7745c5c3_Err = DomainRowsFragment(props.Domains, csrfToken).Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = DomainRowsFragment(props.Domains, csrfToken, canManage).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else if len(props.Groups) == 0 {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<div class=\"trow-empty\">no domains match your search</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "<div class=\"trow-empty\">no domains match your search</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
 			for _, g := range props.Groups {
-				templ_7745c5c3_Err = DomainGroupRow(g, csrfToken).Render(ctx, templ_7745c5c3_Buffer)
+				templ_7745c5c3_Err = DomainGroupRow(g, csrfToken, canManage).Render(ctx, templ_7745c5c3_Buffer)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -348,7 +374,7 @@ func DomainTableBody(props DomainsPageProps, csrfToken string) templ.Component {
 // DomainGroupRow renders one apex group: the apex header row (whose click
 // toggles the group via the $collapsed array signal) followed by its child rows
 // as grid siblings so column alignment is preserved.
-func DomainGroupRow(g DomainGroupView, csrfToken string) templ.Component {
+func DomainGroupRow(g DomainGroupView, csrfToken string, canManage bool) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -374,7 +400,7 @@ func DomainGroupRow(g DomainGroupView, csrfToken string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<div class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<div class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -387,101 +413,101 @@ func DomainGroupRow(g DomainGroupView, csrfToken string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "\" data-class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "\" data-class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var21 string
 		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(collapsedClass(g.Apex))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 152, Col: 37}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 158, Col: 37}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "\" data-on:click=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "\" data-on:click=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var22 string
 		templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(toggleCollapse(g.Apex))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 153, Col: 40}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 159, Col: 40}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "\"><div class=\"dname\"><span class=\"disc\">▾</span> <span class=\"sdot\"></span> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "\"><div class=\"dname\"><span class=\"disc\">▾</span> <span class=\"sdot\"></span> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if g.HasOwn {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "<a href=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<a href=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var23 templ.SafeURL
 			templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("/app/domains/" + g.Header.UID))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 160, Col: 57}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 166, Col: 57}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "\" class=\"n\" data-on:click=\"evt.stopPropagation()\" style=\"text-decoration:none;color:inherit\"><b>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "\" class=\"n\" data-on:click=\"evt.stopPropagation()\" style=\"text-decoration:none;color:inherit\"><b>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var24 string
 			templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(g.Apex)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 164, Col: 16}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 170, Col: 16}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "</b></a> ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "</b></a> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "<span class=\"n\"><b>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "<span class=\"n\"><b>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var25 string
 			templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(g.Apex)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 166, Col: 31}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 172, Col: 31}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "</b></span> ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "</b></span> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
 		if g.SubCount > 0 {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<span class=\"subcount\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "<span class=\"subcount\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var26 string
 			templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(subLabel(g.SubCount))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 169, Col: 49}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 175, Col: 49}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "</span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -490,20 +516,20 @@ func DomainGroupRow(g DomainGroupView, csrfToken string) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "</div><span class=\"cell-mono\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "</div><span class=\"cell-mono\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var27 string
 		templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(g.Header.RecordCount)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 173, Col: 48}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 179, Col: 48}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "</span> <span>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "</span> <span>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -512,7 +538,7 @@ func DomainGroupRow(g DomainGroupView, csrfToken string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "<span class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "<span class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -525,12 +551,12 @@ func DomainGroupRow(g DomainGroupView, csrfToken string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if g.FindingsSeverity == "info" && g.FindingsLabel == "scanning" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "<span class=\"pulse\"></span> ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "<span class=\"pulse\"></span> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -538,31 +564,31 @@ func DomainGroupRow(g DomainGroupView, csrfToken string) templ.Component {
 		var templ_7745c5c3_Var30 string
 		templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs(g.FindingsLabel)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 179, Col: 21}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 185, Col: 21}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "</span></span> <span class=\"cell-mono\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "</span></span> <span class=\"cell-mono\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var31 string
 		templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs(g.Header.LastScan)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 182, Col: 45}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 188, Col: 45}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "</span> <span class=\"chev\">→</span></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "</span> <span class=\"chev\">→</span></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		for i, c := range g.Children {
-			templ_7745c5c3_Err = DomainChildRow(c, g.Apex, i == len(g.Children)-1, csrfToken).Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = DomainChildRow(c, g.Apex, i == len(g.Children)-1, csrfToken, canManage).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -574,7 +600,7 @@ func DomainGroupRow(g DomainGroupView, csrfToken string) templ.Component {
 // DomainChildRow renders a subdomain under its apex: indented with a tree
 // connector, showing only the label in bold against the dimmed apex. Hidden when
 // the parent group is collapsed (data-show keyed on the same $collapsed signal).
-func DomainChildRow(c DomainRowView, apex string, last bool, csrfToken string) templ.Component {
+func DomainChildRow(c DomainRowView, apex string, last bool, csrfToken string, canManage bool) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -600,7 +626,7 @@ func DomainChildRow(c DomainRowView, apex string, last bool, csrfToken string) t
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "<div class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "<div class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -613,85 +639,85 @@ func DomainChildRow(c DomainRowView, apex string, last bool, csrfToken string) t
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "\" id=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "\" id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var35 string
 		templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.JoinStringErrs("domain-row-" + c.UID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 196, Col: 28}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 202, Col: 28}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var35))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "\" data-show=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "\" data-show=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var36 string
 		templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinStringErrs(notCollapsed(apex))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 197, Col: 32}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 203, Col: 32}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var36))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "\"><a href=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "\"><a href=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var37 templ.SafeURL
 		templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("/app/domains/" + c.UID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 199, Col: 50}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 205, Col: 50}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var37))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "\" style=\"display:contents;text-decoration:none;color:inherit\"><div class=\"dname\"><span class=\"sdot\"></span> <span class=\"n\"><span class=\"lead\"><b>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "\" style=\"display:contents;text-decoration:none;color:inherit\"><div class=\"dname\"><span class=\"sdot\"></span> <span class=\"n\"><span class=\"lead\"><b>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var38 string
 		templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.JoinStringErrs(childLabel(c.Name, apex))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 202, Col: 68}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 208, Col: 68}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var38))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "</b>.")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "</b>.")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var39 string
 		templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinStringErrs(apex)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 202, Col: 81}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 208, Col: 81}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var39))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "</span></span></div><span class=\"cell-mono\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "</span></span></div><span class=\"cell-mono\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var40 string
 		templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.JoinStringErrs(c.RecordCount)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 204, Col: 42}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 210, Col: 42}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var40))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "</span> <span>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "</span> <span>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -700,7 +726,7 @@ func DomainChildRow(c DomainRowView, apex string, last bool, csrfToken string) t
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "<span class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "<span class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -713,12 +739,12 @@ func DomainChildRow(c DomainRowView, apex string, last bool, csrfToken string) t
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if c.FindingsSeverity == "info" && c.FindingsLabel == "scanning" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "<span class=\"pulse\"></span> ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "<span class=\"pulse\"></span> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -726,39 +752,49 @@ func DomainChildRow(c DomainRowView, apex string, last bool, csrfToken string) t
 		var templ_7745c5c3_Var43 string
 		templ_7745c5c3_Var43, templ_7745c5c3_Err = templ.JoinStringErrs(c.FindingsLabel)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 210, Col: 22}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 216, Col: 22}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var43))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "</span></span> <span class=\"cell-mono\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "</span></span> <span class=\"cell-mono\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var44 string
 		templ_7745c5c3_Var44, templ_7745c5c3_Err = templ.JoinStringErrs(c.LastScan)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 213, Col: 39}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 219, Col: 39}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var44))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "</span></a> <span class=\"chev\" style=\"display:flex;align-items:center;gap:8px;justify-content:flex-end\"><button type=\"button\" style=\"background:transparent;border:0;color:var(--txt-faint);cursor:pointer;font-size:13px;padding:2px 6px;border-radius:4px\" data-on:click=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, "</span></a> <span class=\"chev\" style=\"display:flex;align-items:center;gap:8px;justify-content:flex-end\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var45 string
-		templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.JoinStringErrs(deleteRowWithConfirm("/app/domains/"+c.UID, csrfToken))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 219, Col: 74}
+		if canManage {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, "<button type=\"button\" style=\"background:transparent;border:0;color:var(--txt-faint);cursor:pointer;font-size:13px;padding:2px 6px;border-radius:4px\" data-on:click=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var45 string
+			templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.JoinStringErrs(deleteRowWithConfirm("/app/domains/"+c.UID, csrfToken))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 226, Col: 75}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var45))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, "\">✕</button> ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var45))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "\">✕</button> →</span></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 60, "→</span></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -788,7 +824,7 @@ func RollupDots(severities []string) templ.Component {
 			templ_7745c5c3_Var46 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "<span class=\"rollup\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 61, "<span class=\"rollup\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -798,7 +834,7 @@ func RollupDots(severities []string) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "<i class=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, "<i class=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -811,12 +847,12 @@ func RollupDots(severities []string) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "\"></i>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 63, "\"></i>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, "</span>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 64, "</span>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -826,7 +862,7 @@ func RollupDots(severities []string) templ.Component {
 
 // DomainRowsFragment renders the inner content of #domains-rows: every domain
 // row, or an empty-state line. Shared by the full page and the search SSE patch.
-func DomainRowsFragment(domains []DomainRowView, csrfToken string) templ.Component {
+func DomainRowsFragment(domains []DomainRowView, csrfToken string, canManage bool) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -848,13 +884,13 @@ func DomainRowsFragment(domains []DomainRowView, csrfToken string) templ.Compone
 		}
 		ctx = templ.ClearChildren(ctx)
 		if len(domains) == 0 {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, "<div class=\"trow-empty\">no domains match your search</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 65, "<div class=\"trow-empty\">no domains match your search</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
 			for _, d := range domains {
-				templ_7745c5c3_Err = DomainRow(d, csrfToken).Render(ctx, templ_7745c5c3_Buffer)
+				templ_7745c5c3_Err = DomainRow(d, csrfToken, canManage).Render(ctx, templ_7745c5c3_Buffer)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -864,7 +900,7 @@ func DomainRowsFragment(domains []DomainRowView, csrfToken string) templ.Compone
 	})
 }
 
-func DomainRow(d DomainRowView, csrfToken string) templ.Component {
+func DomainRow(d DomainRowView, csrfToken string, canManage bool) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -890,7 +926,7 @@ func DomainRow(d DomainRowView, csrfToken string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, "<div class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 66, "<div class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -903,59 +939,59 @@ func DomainRow(d DomainRowView, csrfToken string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 60, "\" id=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 67, "\" id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var53 string
 		templ_7745c5c3_Var53, templ_7745c5c3_Err = templ.JoinStringErrs("domain-row-" + d.UID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 250, Col: 28}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 258, Col: 28}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var53))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 61, "\"><a href=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 68, "\"><a href=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var54 templ.SafeURL
 		templ_7745c5c3_Var54, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("/app/domains/" + d.UID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 252, Col: 50}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 260, Col: 50}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var54))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, "\" style=\"display:contents;text-decoration:none;color:inherit\"><div class=\"dname\"><span class=\"sdot\"></span> <span class=\"n\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 69, "\" style=\"display:contents;text-decoration:none;color:inherit\"><div class=\"dname\"><span class=\"sdot\"></span> <span class=\"n\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var55 string
 		templ_7745c5c3_Var55, templ_7745c5c3_Err = templ.JoinStringErrs(d.Name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 255, Col: 28}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 263, Col: 28}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var55))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 63, "</span></div><span class=\"cell-mono\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 70, "</span></div><span class=\"cell-mono\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var56 string
 		templ_7745c5c3_Var56, templ_7745c5c3_Err = templ.JoinStringErrs(d.RecordCount)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 257, Col: 42}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 265, Col: 42}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var56))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 64, "</span> <span>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 71, "</span> <span>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -964,7 +1000,7 @@ func DomainRow(d DomainRowView, csrfToken string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 65, "<span class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 72, "<span class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -977,12 +1013,12 @@ func DomainRow(d DomainRowView, csrfToken string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 66, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 73, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if d.FindingsSeverity == "info" && d.FindingsLabel == "scanning" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 67, "<span class=\"pulse\"></span> ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 74, "<span class=\"pulse\"></span> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -990,39 +1026,49 @@ func DomainRow(d DomainRowView, csrfToken string) templ.Component {
 		var templ_7745c5c3_Var59 string
 		templ_7745c5c3_Var59, templ_7745c5c3_Err = templ.JoinStringErrs(d.FindingsLabel)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 263, Col: 22}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 271, Col: 22}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var59))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 68, "</span></span> <span class=\"cell-mono\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 75, "</span></span> <span class=\"cell-mono\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var60 string
 		templ_7745c5c3_Var60, templ_7745c5c3_Err = templ.JoinStringErrs(d.LastScan)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 266, Col: 39}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 274, Col: 39}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var60))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 69, "</span></a> <span class=\"chev\" style=\"display:flex;align-items:center;gap:8px;justify-content:flex-end\"><button type=\"button\" style=\"background:transparent;border:0;color:var(--txt-faint);cursor:pointer;font-size:13px;padding:2px 6px;border-radius:4px\" data-on:click=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 76, "</span></a> <span class=\"chev\" style=\"display:flex;align-items:center;gap:8px;justify-content:flex-end\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var61 string
-		templ_7745c5c3_Var61, templ_7745c5c3_Err = templ.JoinStringErrs(deleteRowWithConfirm("/app/domains/"+d.UID, csrfToken))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 272, Col: 74}
+		if canManage {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 77, "<button type=\"button\" style=\"background:transparent;border:0;color:var(--txt-faint);cursor:pointer;font-size:13px;padding:2px 6px;border-radius:4px\" data-on:click=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var61 string
+			templ_7745c5c3_Var61, templ_7745c5c3_Err = templ.JoinStringErrs(deleteRowWithConfirm("/app/domains/"+d.UID, csrfToken))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 281, Col: 75}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var61))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 78, "\">✕</button> ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var61))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 70, "\">✕</button> →</span></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 79, "→</span></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/ui/templates/render_test.go
+++ b/internal/ui/templates/render_test.go
@@ -79,13 +79,14 @@ func TestDomainsPageRender(t *testing.T) {
 	var buf bytes.Buffer
 	props := templates.DomainsPageProps{
 		Shell: templates.AppShellProps{
-			TenantName:   "acme-corp",
-			UserEmail:    "daniel",
-			UserInitials: "DM",
-			ActiveNav:    "domains",
-			AppVersion:   "v0.3.1-alpha",
-			ResolverOK:   true,
-			CSRFToken:    "tok",
+			TenantName:       "acme-corp",
+			UserEmail:        "daniel",
+			UserInitials:     "DM",
+			ActiveNav:        "domains",
+			AppVersion:       "v0.3.1-alpha",
+			ResolverOK:       true,
+			CSRFToken:        "tok",
+			CanManageDomains: true,
 		},
 		Stats: templates.DomainsStats{
 			Tracked:  "3",
@@ -145,6 +146,46 @@ func TestDomainsPageRender(t *testing.T) {
 	}
 }
 
+// TestDomainsPageControlsGatedForViewer pins the page-chrome gate: a viewer
+// (CanManageDomains=false) sees the list but none of the mutation controls —
+// no rescan-all, no add-domain button, no add drawer. The server guard remains
+// the backstop; this keeps the UI honest about what the viewer may do.
+func TestDomainsPageControlsGatedForViewer(t *testing.T) {
+	var buf bytes.Buffer
+	props := templates.DomainsPageProps{
+		Shell: templates.AppShellProps{
+			ActiveNav:        "domains",
+			CSRFToken:        "tok",
+			CanManageDomains: false,
+		},
+		Stats:  templates.DomainsStats{Tracked: "1"},
+		Layout: "flat",
+		Domains: []templates.DomainRowView{
+			{UID: "dom_001", Name: "example.com", FindingsSeverity: "ok"},
+		},
+	}
+	if err := templates.DomainsPage(props).Render(context.Background(), &buf); err != nil {
+		t.Fatalf("DomainsPage render error: %v", err)
+	}
+	out := buf.String()
+	// The viewer still sees the list itself.
+	if !strings.Contains(out, "example.com") {
+		t.Error("expected the domain list to render for a viewer")
+	}
+	if strings.Contains(out, "Rescan all tracked domains?") {
+		t.Error("viewer must not see the rescan-all control")
+	}
+	if strings.Contains(out, "$drawerOpen = true") {
+		t.Error("viewer must not see the add-domain trigger")
+	}
+	if strings.Contains(out, `class="drawer"`) {
+		t.Error("viewer must not see the add-domain drawer")
+	}
+	if strings.Contains(out, "@delete(") {
+		t.Error("viewer must not see any row delete control")
+	}
+}
+
 func TestDomainTableBodyNestedRender(t *testing.T) {
 	props := templates.DomainsPageProps{
 		Layout: "nested",
@@ -177,7 +218,7 @@ func TestDomainTableBodyNestedRender(t *testing.T) {
 		},
 	}
 	var buf bytes.Buffer
-	if err := templates.DomainTableBody(props, "tok").Render(context.Background(), &buf); err != nil {
+	if err := templates.DomainTableBody(props, "tok", true).Render(context.Background(), &buf); err != nil {
 		t.Fatalf("DomainTableBody render error: %v", err)
 	}
 	out := buf.String()
@@ -250,7 +291,7 @@ func TestDomainRowsFragmentRender(t *testing.T) {
 			LastScan:         "1h ago",
 		},
 	}
-	if err := templates.DomainRowsFragment(rows, "tok").Render(context.Background(), &buf); err != nil {
+	if err := templates.DomainRowsFragment(rows, "tok", true).Render(context.Background(), &buf); err != nil {
 		t.Fatalf("DomainRowsFragment render error: %v", err)
 	}
 	if !strings.Contains(buf.String(), "a.example.com") {
@@ -258,7 +299,7 @@ func TestDomainRowsFragmentRender(t *testing.T) {
 	}
 
 	var empty bytes.Buffer
-	if err := templates.DomainRowsFragment(nil, "tok").Render(context.Background(), &empty); err != nil {
+	if err := templates.DomainRowsFragment(nil, "tok", true).Render(context.Background(), &empty); err != nil {
 		t.Fatalf("DomainRowsFragment empty render error: %v", err)
 	}
 	if !strings.Contains(empty.String(), "trow-empty") {
@@ -277,7 +318,7 @@ func TestDomainRowRender(t *testing.T) {
 		FindingsSeverity: "warn",
 		LastScan:         "3d ago",
 	}
-	err := templates.DomainRow(row, "csrf-tok").Render(context.Background(), &buf)
+	err := templates.DomainRow(row, "csrf-tok", true).Render(context.Background(), &buf)
 	if err != nil {
 		t.Fatalf("DomainRow render error: %v", err)
 	}
@@ -287,6 +328,40 @@ func TestDomainRowRender(t *testing.T) {
 	}
 	if !strings.Contains(out, "domain-row-dom_002") {
 		t.Error("expected row id in DomainRow output")
+	}
+	// canManage=true renders the delete control (the ✕ button).
+	if !strings.Contains(out, "✕") {
+		t.Error("expected delete control for a manager")
+	}
+}
+
+// TestDomainRowDeleteGatedByRole pins the per-row delete control to owner/manager:
+// a viewer (canManage=false) sees the row but no delete button, mirroring the
+// service-layer guard so the hidden control matches what the API would reject.
+func TestDomainRowDeleteGatedByRole(t *testing.T) {
+	row := templates.DomainRowView{
+		UID:              "dom_003",
+		Name:             "viewer.example.com",
+		Severity:         "ok",
+		RecordCount:      "3",
+		FindingsLabel:    "healthy",
+		FindingsSeverity: "ok",
+		LastScan:         "2h ago",
+	}
+
+	var viewer bytes.Buffer
+	if err := templates.DomainRow(row, "tok", false).Render(context.Background(), &viewer); err != nil {
+		t.Fatalf("DomainRow viewer render error: %v", err)
+	}
+	vout := viewer.String()
+	if !strings.Contains(vout, "viewer.example.com") {
+		t.Error("expected the row itself to render for a viewer")
+	}
+	if strings.Contains(vout, "✕") {
+		t.Error("viewer must not see the delete control")
+	}
+	if strings.Contains(vout, "@delete(") {
+		t.Error("viewer output should not wire a delete action")
 	}
 }
 

--- a/internal/ui/templates/views.go
+++ b/internal/ui/templates/views.go
@@ -90,6 +90,10 @@ type AppShellProps struct {
 	AppVersion   string
 	CSRFToken    string
 	ResolverOK   bool
+	// CanManageDomains gates the owner/manager-only domain controls (add, rescan,
+	// delete). It mirrors the service-layer guard so the UI hides what the API would
+	// reject; the 403 remains the authoritative backstop.
+	CanManageDomains bool
 }
 
 // LoginPageProps holds data for the login page.

--- a/scripts/verify-auth.sh
+++ b/scripts/verify-auth.sh
@@ -144,6 +144,37 @@ check 403 "viewer CANNOT create an API key (control)"
 req PUT "/api/users/$VIEWER_UID" "$OWNER_KEY" "{\"email\":\"$VIEWER_EMAIL\",\"role\":\"owner\"}"
 check 200 "owner CAN promote to owner (control)"
 
+# the promote above re-roled the viewer; mint a fresh viewer for the domain checks
+DGUARD_VIEWER_EMAIL="dguard-viewer+$TS@a.test"
+invite_accept "$DGUARD_VIEWER_EMAIL" viewer; DGUARD_VIEWER_KEY="$INVITED_KEY"
+
+# ── domain mutation role guard: viewers are read-only for domains ────────────────
+echo
+echo "Domains — ownerOrManager guard on create/update/delete"
+
+req POST /api/domains "$OWNER_KEY" "{\"domain\":\"guard-$TS.example.com\"}"
+check 201 "owner CAN create a domain (control)"
+DGUARD_UID="$(jqr .uid)"; need "$DGUARD_UID" "guarded domain uid"
+
+req POST /api/domains "$DGUARD_VIEWER_KEY" "{\"domain\":\"viewer-$TS.example.com\"}"
+check 403 "viewer CANNOT create a domain"
+
+req PUT "/api/domains/$DGUARD_UID" "$DGUARD_VIEWER_KEY" '{"status":"inactive"}'
+check 403 "viewer CANNOT update a domain"
+
+req DELETE "/api/domains/$DGUARD_UID" "$DGUARD_VIEWER_KEY"
+check 403 "viewer CANNOT delete a domain"
+
+# the forbidden delete left the domain intact
+req GET "/api/domains/$DGUARD_UID" "$OWNER_KEY"
+check 200 "domain survives the forbidden viewer delete (control)"
+
+req PUT "/api/domains/$DGUARD_UID" "$MGR_KEY" '{"status":"active"}'
+check 200 "manager CAN update a domain (control)"
+
+req DELETE "/api/domains/$DGUARD_UID" "$OWNER_KEY"
+check 204 "owner CAN delete a domain (control)"
+
 # ── last-owner guard: a tenant can never be orphaned ─────────────────────────────
 echo
 echo "Tenant integrity — withLastOwnerGuard (fresh sole-owner tenant)"


### PR DESCRIPTION
## Summary

Closes #27.

A `viewer`-role principal could create, update, and delete domains via both the API (`POST`/`PUT`/`DELETE /api/domains/{id}`) and the browser UI. `Update`/`Delete` also schedule scans and cascade to records/findings, so a read-only key could force fleet-wide rescans or destroy data.

This gates all three `DomainsService` mutations behind `ownerOrManager` — the same guard already used by API-key and user management — placed *before* the existence lookup so a viewer receives a uniform `403` with no existence oracle.

## Changes

- **service**: `ownerOrManager` guard on `Create` / `Update` / `Delete`. Exported `OwnerOrManager(p)` predicate as the single source of truth; the `ownerOrManager` API guard and the UI control-visibility both derive from it, so the two surfaces can't drift.
- **server**: map `service.ErrForbidden` → `403` in the three domain handlers.
- **ui**: forbidden mutations render a permission toast instead of a 500/error fragment; the Add / Delete / Rescan / Rescan-all controls are hidden for viewers (the `403` stays the authoritative backstop).
- **tests**: service unit tests, a chi→Huma integration test (`TestAuth_DomainMutationRoleGuard`), templ render-gating tests, and new domain-guard checks in the `verify-auth.sh` e2e.

## Decision

`Create` is gated too (not just `Update`/`Delete`): a `viewer` is read-only and creating a domain triggers a scan, so gating all three keeps the role boundary consistent. Viewers lose the ability to add domains in both API and UI.

## Note on the lint stage

The `lint` CI stage was already red on `main` (the last several PRs merged red) due to pre-existing issues in `internal/testhelpers/containers.go` (from #25): a `betteralign` struct misalignment, `golines` long-lines, and an unused `prepareDatabase` function. This PR clears those so the full `lint-test-build` pipeline is green again.
