### PR TITLE
Fix zone-transfer subsystem correctness (#28)

### DIFF
--- a/internal/assessor/assess_zone_transfer.go
+++ b/internal/assessor/assess_zone_transfer.go
@@ -76,7 +76,7 @@ type SecurityWarnings struct {
 func (a *Assessor) AssessZoneTransfer(ctx context.Context, domainUID string) error {
 	domain, err := a.store.DomainsGetByIdentifier(ctx, store.DomainsGetByIdentifierParams{
 		Uid:      domainUID,
-		TenantID: pgtype.Int4{Int32: 1, Valid: true}, // todo: replace with actual tenant ID
+		TenantID: pgtype.Int4{Int32: a.identity.TenantID, Valid: true},
 	})
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -99,94 +99,175 @@ func (a *Assessor) AssessZoneTransfer(ctx context.Context, domainUID string) err
 		a.logger.ErrorContext(ctx, "Failed to retrieve zone transfer attempts", "error", err)
 		return err
 	}
-	successfulAssessments := 0
+	nsIDByHost := a.nsRecordIDsByHost(ctx, domain.ID)
+
+	assessed := 0
 	for _, attempt := range attempts {
+		nsRecordID := nsRecordIDFor(attempt.Nameserver, nsIDByHost)
+		var recorded bool
 		if attempt.WasSuccessful {
-			var transferData dnsrecords.ZoneTransferData
-			if err := json.Unmarshal(attempt.ResponseData, &transferData); err != nil {
-				a.logger.ErrorContext(
-					ctx,
-					"Failed to unmarshal zone transfer data",
-					"error",
-					err,
-					"nameserver",
-					attempt.Nameserver,
-				)
-				continue
-			}
-			assessment := ExtractZoneTransferAssessment(&transferData)
-
-			recordData := extractRecordDataByType(&transferData)
-			findings := FindingsContainer{
-				PrimaryFinding: Finding{
-					Title: fmt.Sprintf(
-						"Zone transfer (%s) allowed from nameserver %s",
-						attempt.TransferType,
-						attempt.Nameserver,
-					),
-					Severity: string(store.FindingSeverityCritical),
-					Details: fmt.Sprintf(
-						"Zone transfer (%s) allowed from nameserver %s. This can leak internal DNS information to attackers.",
-						attempt.TransferType,
-						attempt.Nameserver,
-					),
-				},
-				Assessment: assessment,
-				RecordData: recordData,
-			}
-
-			findings.SensitiveInfo = collectSensitiveInfoFindings(assessment)
-			findings.InternalExposure = collectInternalExposureFindings(assessment)
-			findings.SecurityIssues = collectSecurityFlagFindings(assessment)
-			findingsJSON, err := json.Marshal(findings)
-			if err != nil {
-				a.logger.ErrorContext(ctx, "Failed to marshal findings data", "error", err)
-				continue
-			}
-
-			_, sErr := a.store.StoreZoneTransferFinding(ctx, store.StoreZoneTransferFindingParams{
-				DomainID:             pgtype.Int4{Int32: domain.ID, Valid: true},
-				Severity:             store.FindingSeverityCritical,
-				Status:               store.FindingStatusOpen,
-				Nameserver:           attempt.Nameserver,
-				ZoneTransferPossible: true,
-				TransferType:         attempt.TransferType,
-				TransferDetails:      findingsJSON,
-			})
-			if sErr != nil {
-				a.logger.ErrorContext(ctx, "Failed to store zone transfer finding", "error", sErr)
-				continue
-			}
-			payload := observer.PayloadJSON(map[string]any{
-				"nameserver":             attempt.Nameserver,
-				"transfer_type":          string(attempt.TransferType),
-				"severity":               string(store.FindingSeverityCritical),
-				"zone_transfer_possible": true,
-			})
-			if oErr := observer.New(a.store).RecordFindingChange(
-				ctx, a.identity, observer.EntityZoneTransferFinding, attempt.Nameserver, payload,
-			); oErr != nil {
-				a.logger.WarnContext(ctx, "failed to emit zone transfer finding observation",
-					"nameserver", attempt.Nameserver, "error", oErr)
-			}
-			successfulAssessments++
+			recorded = a.recordExposedFinding(ctx, domain.ID, attempt, nsRecordID)
+		} else {
+			recorded = a.recordRefusedFinding(ctx, domain.ID, attempt, nsRecordID)
+		}
+		if recorded {
+			assessed++
 		}
 	}
 
-	if successfulAssessments > 0 {
-		a.logger.InfoContext(
-			ctx,
-			"Successfully assessed zone transfers",
-			"domain",
-			domain.Uid,
-			"count",
-			successfulAssessments,
-		)
+	if len(attempts) == 0 {
+		a.logger.InfoContext(ctx, "No zone transfer attempts found to assess", "domain", domain.Uid)
 		return nil
 	}
-	a.logger.InfoContext(ctx, "No zone transfer attempts found to assess", "domain", domain.Uid)
-
+	a.logger.InfoContext(
+		ctx,
+		"Successfully assessed zone transfers",
+		"domain",
+		domain.Uid,
+		"count",
+		assessed,
+	)
 	return nil
+}
+
+// nsRecordIDsByHost maps a domain's NS hostnames to their ns_records row IDs so
+// zone-transfer findings can link back to the originating NS record. A load
+// failure is non-fatal: findings are still written with a null FK.
+func (a *Assessor) nsRecordIDsByHost(ctx context.Context, domainID int32) map[string]int32 {
+	rows, err := a.store.RecordsGetNSByDomainID(ctx, pgtype.Int4{Int32: domainID, Valid: true})
+	if err != nil {
+		a.logger.WarnContext(ctx, "failed to load NS records for finding linkage", "error", err)
+		return nil
+	}
+	byHost := make(map[string]int32, len(rows))
+	for _, r := range rows {
+		byHost[r.Nameserver] = r.ID
+	}
+	return byHost
+}
+
+// nsRecordIDFor resolves the ns_records FK for a stored attempt nameserver,
+// which is formatted as host:port. An unmatched nameserver yields a null FK
+// rather than an error.
+func nsRecordIDFor(attemptNameserver string, byHost map[string]int32) pgtype.Int4 {
+	host := attemptNameserver
+	if h, _, err := net.SplitHostPort(attemptNameserver); err == nil {
+		host = h
+	}
+	if id, ok := byHost[host]; ok {
+		return pgtype.Int4{Int32: id, Valid: true}
+	}
+	return pgtype.Int4{Valid: false}
+}
+
+// recordExposedFinding analyses a successful zone transfer, stores the critical
+// finding with its extracted assessment, and emits its observation. Returns true
+// when the finding row was written.
+func (a *Assessor) recordExposedFinding(
+	ctx context.Context,
+	domainID int32,
+	attempt store.ZoneTransferAttempts,
+	nsRecordID pgtype.Int4,
+) bool {
+	var transferData dnsrecords.ZoneTransferData
+	if err := json.Unmarshal(attempt.ResponseData, &transferData); err != nil {
+		a.logger.ErrorContext(ctx, "Failed to unmarshal zone transfer data",
+			"error", err, "nameserver", attempt.Nameserver)
+		return false
+	}
+	assessment := ExtractZoneTransferAssessment(&transferData)
+	findings := FindingsContainer{
+		PrimaryFinding: Finding{
+			Title: fmt.Sprintf(
+				"Zone transfer (%s) allowed from nameserver %s",
+				attempt.TransferType,
+				attempt.Nameserver,
+			),
+			Severity: string(store.FindingSeverityCritical),
+			Details: fmt.Sprintf(
+				"Zone transfer (%s) allowed from nameserver %s. This can leak internal DNS information to attackers.",
+				attempt.TransferType,
+				attempt.Nameserver,
+			),
+		},
+		Assessment: assessment,
+		RecordData: extractRecordDataByType(&transferData),
+	}
+	findings.SensitiveInfo = collectSensitiveInfoFindings(assessment)
+	findings.InternalExposure = collectInternalExposureFindings(assessment)
+	findings.SecurityIssues = collectSecurityFlagFindings(assessment)
+	findingsJSON, err := json.Marshal(findings)
+	if err != nil {
+		a.logger.ErrorContext(ctx, "Failed to marshal findings data", "error", err)
+		return false
+	}
+
+	_, sErr := a.store.StoreZoneTransferFinding(ctx, store.StoreZoneTransferFindingParams{
+		DomainID:             pgtype.Int4{Int32: domainID, Valid: true},
+		NsRecordID:           nsRecordID,
+		Severity:             store.FindingSeverityCritical,
+		Status:               store.FindingStatusOpen,
+		Nameserver:           attempt.Nameserver,
+		ZoneTransferPossible: true,
+		TransferType:         attempt.TransferType,
+		TransferDetails:      findingsJSON,
+	})
+	if sErr != nil {
+		a.logger.ErrorContext(ctx, "Failed to store zone transfer finding", "error", sErr)
+		return false
+	}
+	payload := observer.PayloadJSON(map[string]any{
+		"nameserver":             attempt.Nameserver,
+		"transfer_type":          string(attempt.TransferType),
+		"severity":               string(store.FindingSeverityCritical),
+		"zone_transfer_possible": true,
+	})
+	if oErr := observer.New(a.store).RecordFindingChange(
+		ctx, a.identity, observer.EntityZoneTransferFinding, attempt.Nameserver, payload,
+	); oErr != nil {
+		a.logger.WarnContext(ctx, "failed to emit zone transfer finding observation",
+			"nameserver", attempt.Nameserver, "error", oErr)
+	}
+	return true
+}
+
+// recordRefusedFinding stores a passing/compliant finding for a nameserver that
+// correctly refused the zone transfer and emits its observation. Returns true
+// when the finding row was written.
+func (a *Assessor) recordRefusedFinding(
+	ctx context.Context,
+	domainID int32,
+	attempt store.ZoneTransferAttempts,
+	nsRecordID pgtype.Int4,
+) bool {
+	details := fmt.Sprintf("Zone transfer refused by %s", attempt.Nameserver)
+	_, err := a.store.StoreZoneTransferFinding(ctx, store.StoreZoneTransferFindingParams{
+		DomainID:             pgtype.Int4{Int32: domainID, Valid: true},
+		NsRecordID:           nsRecordID,
+		Severity:             store.FindingSeverityInfo,
+		Status:               store.FindingStatusCompliant,
+		Nameserver:           attempt.Nameserver,
+		ZoneTransferPossible: false,
+		TransferType:         attempt.TransferType,
+		Details:              pgtype.Text{String: details, Valid: true},
+	})
+	if err != nil {
+		a.logger.ErrorContext(ctx, "Failed to store refused zone transfer finding", "error", err)
+		return false
+	}
+	payload := observer.PayloadJSON(map[string]any{
+		"nameserver":             attempt.Nameserver,
+		"transfer_type":          string(attempt.TransferType),
+		"severity":               string(store.FindingSeverityInfo),
+		"zone_transfer_possible": false,
+	})
+	if oErr := observer.New(a.store).RecordFindingChange(
+		ctx, a.identity, observer.EntityZoneTransferFinding, attempt.Nameserver, payload,
+	); oErr != nil {
+		a.logger.WarnContext(ctx, "failed to emit zone transfer finding observation",
+			"nameserver", attempt.Nameserver, "error", oErr)
+	}
+	return true
 }
 
 // extractRecordDataByType categorizes DNS records from a zone transfer by their record type.

--- a/internal/assessor/assess_zone_transfer_test.go
+++ b/internal/assessor/assess_zone_transfer_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/danielmichaels/gecko/internal/dnsrecords"
+	"github.com/danielmichaels/gecko/internal/observer"
 	"github.com/danielmichaels/gecko/internal/store"
 	"github.com/danielmichaels/gecko/internal/testhelpers"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -37,8 +38,16 @@ func TestAssessZoneTransfer(t *testing.T) {
 		t.Fatalf("Failed to get domain: %v", err)
 	}
 
-	// Create assessor with the logger
-	assessor := NewAssessor(Config{Store: pgContainer.Queries, Logger: testhelpers.TestLogger})
+	// Create assessor with an identity for the seeded tenant-1 domain
+	ident := observer.DomainIdentity{
+		TenantID:   1,
+		DomainID:   domain.ID,
+		DomainUID:  domain.Uid,
+		DomainName: domain.Name,
+	}
+	assessor := NewAssessor(
+		Config{Store: pgContainer.Queries, Logger: testhelpers.TestLogger, Identity: ident},
+	)
 
 	// Create mock zone transfer data
 	mockZoneTransferData := createMockZoneTransferData()
@@ -188,6 +197,97 @@ func TestAssessZoneTransfer(t *testing.T) {
 	}
 	if _, ok := findingsContainer.RecordData["TXT"]; !ok {
 		t.Error("Expected TXT records in raw record data")
+	}
+}
+
+// TestAssessZoneTransferRefusedNonDefaultTenant exercises the three issue #28
+// fixes together on a tenant other than 1: the assessor must look the domain up
+// by the identity's tenant (a), write a passing/compliant finding when every
+// nameserver refuses (b), and link the finding to its NS record (c).
+func TestAssessZoneTransferRefusedNonDefaultTenant(t *testing.T) {
+	ctx := context.Background()
+	pgContainer, err := testhelpers.CreatePostgresContainer(ctx)
+	if err != nil {
+		t.Fatalf("Failed to create postgres container: %v", err)
+	}
+	defer pgContainer.Close(ctx)
+
+	domain, err := pgContainer.Queries.DomainsGetByID(
+		ctx,
+		store.DomainsGetByIDParams{
+			Uid:      "domain_00000002",
+			TenantID: pgtype.Int4{Int32: 2, Valid: true},
+		},
+	)
+	if err != nil {
+		t.Fatalf("Failed to get tenant-2 domain: %v", err)
+	}
+
+	nsRecord, err := pgContainer.Queries.RecordsCreateNS(ctx, store.RecordsCreateNSParams{
+		DomainID:   pgtype.Int4{Int32: domain.ID, Valid: true},
+		Nameserver: "ns1.example-two.test.",
+	})
+	if err != nil {
+		t.Fatalf("Failed to create NS record: %v", err)
+	}
+
+	_, err = pgContainer.Queries.ScannersStoreZoneTransferAttempt(
+		ctx,
+		store.ScannersStoreZoneTransferAttemptParams{
+			DomainID:      pgtype.Int4{Int32: domain.ID, Valid: true},
+			Nameserver:    "ns1.example-two.test.:53",
+			TransferType:  store.TransferTypeAXFRIXFR,
+			WasSuccessful: false,
+			ErrorMessage:  pgtype.Text{String: "Transfer refused or failed", Valid: true},
+		},
+	)
+	if err != nil {
+		t.Fatalf("Failed to store refused zone transfer attempt: %v", err)
+	}
+
+	ident := observer.DomainIdentity{
+		TenantID:   2,
+		DomainID:   domain.ID,
+		DomainUID:  domain.Uid,
+		DomainName: domain.Name,
+	}
+	assessor := NewAssessor(
+		Config{Store: pgContainer.Queries, Logger: testhelpers.TestLogger, Identity: ident},
+	)
+
+	if err := assessor.AssessZoneTransfer(ctx, domain.Uid); err != nil {
+		t.Fatalf("AssessZoneTransfer failed for tenant-2 domain: %v", err)
+	}
+
+	findings, err := pgContainer.Queries.AssessGetZoneTransferFindings(
+		ctx,
+		pgtype.Int4{Int32: domain.ID, Valid: true},
+	)
+	if err != nil {
+		t.Fatalf("Failed to get zone transfer findings: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("Expected exactly 1 refused finding, got %d", len(findings))
+	}
+
+	finding := findings[0]
+	if finding.ZoneTransferPossible {
+		t.Error("Expected ZoneTransferPossible to be false for a refused transfer")
+	}
+	if finding.Severity != store.FindingSeverityInfo {
+		t.Errorf("Expected severity info, got %s", finding.Severity)
+	}
+	if finding.Status != store.FindingStatusCompliant {
+		t.Errorf("Expected status compliant, got %s", finding.Status)
+	}
+	if !finding.Details.Valid || finding.Details.String == "" {
+		t.Error("Expected refused finding to carry a non-empty Details message")
+	}
+	if !finding.NsRecordID.Valid {
+		t.Fatal("Expected NsRecordID to be populated")
+	}
+	if finding.NsRecordID.Int32 != nsRecord.ID {
+		t.Errorf("Expected NsRecordID %d, got %d", nsRecord.ID, finding.NsRecordID.Int32)
 	}
 }
 

--- a/internal/scanner/fake_resolver_test.go
+++ b/internal/scanner/fake_resolver_test.go
@@ -16,9 +16,12 @@ type fakeResolver struct {
 	aaaaReturn  []string
 	aaaaOK      bool
 
-	calledCNAME []string
-	calledA     []string
-	calledAAAA  []string
+	zoneTransferReturn *dnsrecords.ZoneTransferResult
+
+	calledCNAME        []string
+	calledA            []string
+	calledAAAA         []string
+	calledZoneTransfer []string
 }
 
 func (f *fakeResolver) LookupCNAME(target string) ([]string, bool) {
@@ -46,7 +49,11 @@ func (f *fakeResolver) LookupWithStatus(string, uint16) ([]string, dnsclient.Res
 }
 func (f *fakeResolver) IsZoneApex(string) bool      { return false }
 func (f *fakeResolver) ValidateDNSSEC(string) error { return nil }
-func (f *fakeResolver) AttemptZoneTransfer(string) *dnsrecords.ZoneTransferResult {
+func (f *fakeResolver) AttemptZoneTransfer(domain string) *dnsrecords.ZoneTransferResult {
+	f.calledZoneTransfer = append(f.calledZoneTransfer, domain)
+	if f.zoneTransferReturn != nil {
+		return f.zoneTransferReturn
+	}
 	return &dnsrecords.ZoneTransferResult{}
 }
 

--- a/internal/scanner/scan_zonetransfer.go
+++ b/internal/scanner/scan_zonetransfer.go
@@ -19,7 +19,7 @@ import (
 func (s *Scan) ScanZoneTransfer(ctx context.Context, domainName string) (string, error) {
 	domain, err := s.store.DomainsGetByIdentifier(ctx, store.DomainsGetByIdentifierParams{
 		Name:     domainName,
-		TenantID: pgtype.Int4{Int32: 1, Valid: true}, // todo: replace with actual tenant ID
+		TenantID: pgtype.Int4{Int32: s.identity.TenantID, Valid: true},
 	})
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {

--- a/internal/scanner/scan_zonetransfer_test.go
+++ b/internal/scanner/scan_zonetransfer_test.go
@@ -1,0 +1,78 @@
+package scanner
+
+import (
+	"context"
+	"testing"
+
+	"github.com/danielmichaels/gecko/internal/dnsrecords"
+	"github.com/danielmichaels/gecko/internal/observer"
+	"github.com/danielmichaels/gecko/internal/store"
+	"github.com/danielmichaels/gecko/internal/testhelpers"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// TestScanZoneTransferUsesIdentityTenant verifies the scanner looks the domain
+// up by the identity's tenant rather than a hardcoded tenant ID (issue #28a):
+// a tenant-2 domain must be found and its refused attempt recorded.
+func TestScanZoneTransferUsesIdentityTenant(t *testing.T) {
+	ctx := context.Background()
+	pgContainer, err := testhelpers.CreatePostgresContainer(ctx)
+	if err != nil {
+		t.Fatalf("Failed to create postgres container: %v", err)
+	}
+	defer pgContainer.Close(ctx)
+
+	domain, err := pgContainer.Queries.DomainsGetByID(
+		ctx,
+		store.DomainsGetByIDParams{
+			Uid:      "domain_00000002",
+			TenantID: pgtype.Int4{Int32: 2, Valid: true},
+		},
+	)
+	if err != nil {
+		t.Fatalf("Failed to get tenant-2 domain: %v", err)
+	}
+
+	fake := &fakeResolver{
+		zoneTransferReturn: &dnsrecords.ZoneTransferResult{
+			Domain: domain.Name,
+			NS:     []string{"ns1.example-two.test."},
+		},
+	}
+	s := NewScanner(Config{
+		Logger:   testhelpers.TestLogger,
+		Store:    pgContainer.Queries,
+		Resolver: fake,
+		Identity: observer.DomainIdentity{
+			TenantID:   2,
+			DomainID:   domain.ID,
+			DomainUID:  domain.Uid,
+			DomainName: domain.Name,
+		},
+	})
+
+	uid, err := s.ScanZoneTransfer(ctx, domain.Name)
+	if err != nil {
+		t.Fatalf("ScanZoneTransfer failed for tenant-2 domain: %v", err)
+	}
+	if uid != domain.Uid {
+		t.Errorf("Expected returned uid %q, got %q", domain.Uid, uid)
+	}
+
+	attempts, err := pgContainer.Queries.ScannersGetZoneTransferAttempts(
+		ctx,
+		pgtype.Int4{Int32: domain.ID, Valid: true},
+	)
+	if err != nil {
+		t.Fatalf("Failed to get zone transfer attempts: %v", err)
+	}
+	if len(attempts) != 1 {
+		t.Fatalf("Expected 1 recorded attempt, got %d", len(attempts))
+	}
+	if attempts[0].WasSuccessful {
+		t.Error("Expected the recorded attempt to be a refusal")
+	}
+	if attempts[0].Nameserver != "ns1.example-two.test.:53" {
+		t.Errorf("Unexpected nameserver: %q", attempts[0].Nameserver)
+	}
+}

--- a/sql/tests/test-data.sql
+++ b/sql/tests/test-data.sql
@@ -23,3 +23,21 @@ SELECT
     'domain_' || LPAD(d.id::text, 8, '0')
 FROM domain_data d
 ON CONFLICT (tenant_id, name) DO NOTHING;
+
+-- Second tenant to exercise multi-tenant code paths (issue #28)
+INSERT INTO tenants (name, uid)
+VALUES ('Test Tenant Two', 'tenant_00000002');
+
+WITH domain_data (id, name) AS (
+    VALUES (2, 'example-two.test')
+)
+INSERT INTO domains (tenant_id, name, domain_type, source, status, uid)
+SELECT
+    (SELECT id FROM tenants WHERE uid = 'tenant_00000002'),
+    d.name,
+    'tld',
+    'user_supplied',
+    'active',
+    'domain_' || LPAD(d.id::text, 8, '0')
+FROM domain_data d
+ON CONFLICT (tenant_id, name) DO NOTHING;


### PR DESCRIPTION
## Summary

Fixes the three correctness bugs in the zone-transfer scan→assess path tracked in #28.

### (a) Hardcoded `TenantID: 1` — multi-tenant breakage
Both the scanner and assessor re-looked-up the domain with a hardcoded tenant ID of `1`, despite the correct tenant already being threaded in via the job's `DomainIdentity`. For any tenant ≠ 1 the lookup returned no row, the scan aborted, and no finding was ever written. Now uses `s.identity.TenantID` / `a.identity.TenantID`.

### (b) No finding row when zone transfer is correctly refused
`AssessZoneTransfer` only wrote a finding for *successful* transfers, so a correctly-configured domain showed as never-assessed instead of passing. It now writes an `info`/`compliant`, `zone_transfer_possible=false` row when a nameserver refuses — which the existing `mapZoneTransferFinding` / `FindingsListByTenant` display path already renders as a passing "ok" finding.

### (c) `NsRecordID` never populated
The FK from a zone-transfer finding back to its originating NS record was always NULL. It is now resolved by stripping the `:53` port from the attempt nameserver and matching against the domain's NS records (`RecordsGetNSByDomainID`). Unmatched nameservers degrade to a NULL FK rather than failing the assessment. No SQL/sqlc change required.

## Notes
- Adds `tenant_00000002` + `domain_00000002` to the test seed and tenant-≠-1 integration tests covering the scanner lookup, the refused-transfer finding, and the `NsRecordID` linkage.
- The successful-finding path was extracted into `recordExposedFinding` to mirror `recordRefusedFinding` and keep the assessment loop symmetric.
