### PR TITLE
Scans REST API: single-scan diff detail endpoint (#34)

### DIFF
--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -211,6 +211,16 @@ func (app *Server) registerEndpoints(api huma.API) {
 		Security:      []map[string][]string{{"xApiKey": []string{"x-api-key"}}},
 		Middlewares:   huma.Middlewares{app.apiAuth(api)},
 	}, app.handleScansList)
+	huma.Register(api, huma.Operation{
+		OperationID:   "get_scan",
+		Method:        http.MethodGet,
+		Path:          "/api/scans/{uid}",
+		Summary:       "Get a single scan with its per-observation diff detail",
+		Tags:          []string{"Scans"},
+		DefaultStatus: http.StatusOK,
+		Security:      []map[string][]string{{"xApiKey": []string{"x-api-key"}}},
+		Middlewares:   huma.Middlewares{app.apiAuth(api)},
+	}, app.handleScanDetail)
 
 	// Auth handlers (public: signup, login, accept-invite)
 	huma.Register(api, huma.Operation{

--- a/internal/server/scans_api_handlers.go
+++ b/internal/server/scans_api_handlers.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"time"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -105,5 +107,63 @@ func (app *Server) handleScansList(
 	resp := &ScansListOutput{}
 	resp.Body.Pagination = &pagination
 	resp.Body.Scans = items
+	return resp, nil
+}
+
+// ScanObservationItem is one entity-level change recorded during a scan, the
+// machine-facing diff row.
+type ScanObservationItem struct {
+	ObservedAt time.Time       `json:"observed_at"`
+	EntityType string          `json:"entity_type"`
+	EntityKey  string          `json:"entity_key"`
+	ChangeType string          `json:"change_type"`
+	Payload    json.RawMessage `json:"payload"`
+}
+
+type ScanDetailInput struct {
+	UID string `path:"uid" example:"scan_00000001" doc:"Scan UID"`
+}
+
+type ScanDetailOutput struct {
+	Body struct {
+		Scan         ScanItem              `json:"scan"`
+		Observations []ScanObservationItem `json:"observations"`
+	}
+}
+
+// handleScanDetail serves a single scan by uid: its change aggregate (same shape
+// as a feed row) plus the full per-observation diff detail. Tenant-scoped — an
+// unknown or cross-tenant uid is a 404.
+func (app *Server) handleScanDetail(
+	ctx context.Context,
+	i *ScanDetailInput,
+) (*ScanDetailOutput, error) {
+	p, err := principalOrErr(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	detail, err := app.Svc.ScansService().GetByUID(ctx, p, i.UID)
+	if err != nil {
+		if errors.Is(err, service.ErrNotFound) {
+			return nil, huma.Error404NotFound("scan not found")
+		}
+		return nil, huma.Error500InternalServerError("failed to get scan", err)
+	}
+
+	observations := make([]ScanObservationItem, 0, len(detail.Observations))
+	for _, o := range detail.Observations {
+		observations = append(observations, ScanObservationItem{
+			EntityType: o.EntityType,
+			EntityKey:  o.EntityKey,
+			ChangeType: o.ChangeType,
+			Payload:    o.Payload,
+			ObservedAt: o.ObservedAt,
+		})
+	}
+
+	resp := &ScanDetailOutput{}
+	resp.Body.Scan = toScanItem(detail.FlatScanView)
+	resp.Body.Observations = observations
 	return resp, nil
 }

--- a/internal/server/scans_api_integration_test.go
+++ b/internal/server/scans_api_integration_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"testing"
 	"time"
@@ -82,9 +83,35 @@ func (r scansListResp) hasScan(uid string) bool {
 	return false
 }
 
-// TestScansAPI exercises the /api/scans feed through the full chi → huma → apiAuth
-// chain: tenant isolation, the default 7-day window (and the all-time escape hatch),
-// source filtering, and missing-key rejection.
+type scansDetailResp struct {
+	Scan struct {
+		ScanUID      string `json:"scan_uid"`
+		DomainName   string `json:"domain_name"`
+		State        string `json:"state"`
+		TotalChanges int    `json:"total_changes"`
+		IsBaseline   bool   `json:"is_baseline"`
+	} `json:"scan"`
+	Observations []struct {
+		EntityType string          `json:"entity_type"`
+		EntityKey  string          `json:"entity_key"`
+		ChangeType string          `json:"change_type"`
+		Payload    json.RawMessage `json:"payload"`
+	} `json:"observations"`
+}
+
+func (r scansDetailResp) hasObservation(entityKey, changeType string) bool {
+	for _, o := range r.Observations {
+		if o.EntityKey == entityKey && o.ChangeType == changeType {
+			return true
+		}
+	}
+	return false
+}
+
+// TestScansAPI exercises the /api/scans feed and /api/scans/{uid} detail through
+// the full chi → huma → apiAuth chain: tenant isolation (feed and per-scan),
+// the default 7-day window (and the all-time escape hatch), source/q/changed_only
+// filtering, the per-scan observation diff, and missing-key rejection.
 func TestScansAPI(t *testing.T) {
 	testhelpers.ParallelDBTest(t)
 	ctx := context.Background()
@@ -182,6 +209,81 @@ func TestScansAPI(t *testing.T) {
 	t.Run("no key rejected", func(t *testing.T) {
 		if code := doJSON(t, http.MethodGet, base+"/api/scans", "", nil, nil); code != http.StatusUnauthorized {
 			t.Errorf("no key status = %d, want 401", code)
+		}
+	})
+
+	t.Run("detail returns scan with observation diff", func(t *testing.T) {
+		var res scansDetailResp
+		if code := doJSON(t, http.MethodGet, base+"/api/scans/"+recent.Uid, a.APIKey, nil, &res); code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", code)
+		}
+		if res.Scan.ScanUID != recent.Uid {
+			t.Errorf("scan_uid = %q, want %q", res.Scan.ScanUID, recent.Uid)
+		}
+		if res.Scan.DomainName != "acme.com" {
+			t.Errorf("domain_name = %q, want acme.com", res.Scan.DomainName)
+		}
+		if !res.Scan.IsBaseline || res.Scan.State != "baseline" {
+			t.Errorf(
+				"state = %q baseline = %v, want baseline/true",
+				res.Scan.State,
+				res.Scan.IsBaseline,
+			)
+		}
+		if !res.hasObservation("a1", "created") {
+			t.Errorf("observations missing a1/created: %+v", res.Observations)
+		}
+	})
+
+	t.Run("detail cross-tenant 404", func(t *testing.T) {
+		if code := doJSON(t, http.MethodGet, base+"/api/scans/"+otherScan.Uid, a.APIKey, nil, nil); code != http.StatusNotFound {
+			t.Errorf("A -> B scan status = %d, want 404", code)
+		}
+	})
+
+	t.Run("detail unknown uid 404", func(t *testing.T) {
+		if code := doJSON(t, http.MethodGet, base+"/api/scans/scan_doesnotexist", a.APIKey, nil, nil); code != http.StatusNotFound {
+			t.Errorf("unknown uid status = %d, want 404", code)
+		}
+	})
+
+	t.Run("detail no key rejected", func(t *testing.T) {
+		if code := doJSON(t, http.MethodGet, base+"/api/scans/"+recent.Uid, "", nil, nil); code != http.StatusUnauthorized {
+			t.Errorf("no key status = %d, want 401", code)
+		}
+	})
+
+	t.Run("changed_only hides clean re-scans, keeps baselines", func(t *testing.T) {
+		clean := seedScanRow(
+			t, ctx, pc, tenantA, acme,
+			store.DomainSourceUserSupplied,
+			pgtype.Int8{Int64: recent.ID, Valid: true},
+		)
+
+		var res scansListResp
+		if code := doJSON(t, http.MethodGet, base+"/api/scans?changed_only=true&window_days=0", a.APIKey, nil, &res); code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", code)
+		}
+		if res.hasScan(clean.Uid) {
+			t.Errorf("clean re-scan %s present under changed_only", clean.Uid)
+		}
+		if !res.hasScan(recent.Uid) {
+			t.Errorf("baseline scan %s dropped under changed_only", recent.Uid)
+		}
+	})
+
+	t.Run("q filters by domain substring", func(t *testing.T) {
+		var res scansListResp
+		if code := doJSON(t, http.MethodGet, base+"/api/scans?q=acme&window_days=0", a.APIKey, nil, &res); code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", code)
+		}
+		if len(res.Scans) == 0 {
+			t.Fatal("q=acme returned no scans")
+		}
+		for _, s := range res.Scans {
+			if s.DomainName != "acme.com" {
+				t.Errorf("q=acme returned domain %q", s.DomainName)
+			}
 		}
 	})
 }

--- a/internal/service/scans.go
+++ b/internal/service/scans.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"sort"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/danielmichaels/gecko/internal/auth"
 	"github.com/danielmichaels/gecko/internal/store"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
@@ -135,6 +137,81 @@ type FlatScanView struct {
 type FlatScansResult struct {
 	Scans      []FlatScanView
 	TotalCount int64
+}
+
+// ScanObservationDetail is one observation row in a scan's diff detail: the
+// entity that changed, how it changed (change_type: created|updated|deleted), and
+// its recorded payload. UI-only glyph/class fields are intentionally excluded —
+// this is the machine-facing shape.
+type ScanObservationDetail struct {
+	ObservedAt time.Time
+	EntityType string
+	EntityKey  string
+	ChangeType string
+	Payload    json.RawMessage
+}
+
+// ScanDetailView is a single scan — its FlatScanView header and change aggregate
+// — plus the per-observation diff detail, for the scan-detail API.
+type ScanDetailView struct {
+	Observations []ScanObservationDetail
+	FlatScanView
+}
+
+// GetByUID returns one scan by its uid with its change aggregate and full
+// per-observation diff detail. Tenant isolation is the (tenant_id, uid) gate in
+// ScansGetByTenantUID — a cross-tenant or unknown uid yields ErrNotFound. The
+// header derivation (state, counts, breakdown) is reused from the list path via
+// mapScanRow/flatScanView so both endpoints stay in lockstep.
+func (s *ScansService) GetByUID(
+	ctx context.Context,
+	p *auth.Principal,
+	uid string,
+) (ScanDetailView, error) {
+	row, err := s.DB.ScansGetByTenantUID(ctx, store.ScansGetByTenantUIDParams{
+		TenantID: p.TenantID,
+		Uid:      uid,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ScanDetailView{}, ErrNotFound
+		}
+		return ScanDetailView{}, fmt.Errorf("get scan: %w", err)
+	}
+
+	head := flatScanView(mapScanRow(store.ScansListByTenantRow{
+		ScanUid:       row.ScanUid,
+		DomainUid:     row.DomainUid,
+		DomainName:    row.DomainName,
+		Source:        row.Source,
+		StartedAt:     row.StartedAt,
+		ParentScanUid: row.ParentScanUid,
+		CreatedCount:  row.CreatedCount,
+		UpdatedCount:  row.UpdatedCount,
+		DeletedCount:  row.DeletedCount,
+		Breakdown:     row.Breakdown,
+	}, time.Now()))
+
+	obsRows, err := s.DB.ObservationsListByScan(ctx, store.ObservationsListByScanParams{
+		ScanID:   pgtype.Int8{Int64: row.ScanID, Valid: true},
+		TenantID: p.TenantID,
+	})
+	if err != nil {
+		return ScanDetailView{}, fmt.Errorf("list scan observations: %w", err)
+	}
+
+	observations := make([]ScanObservationDetail, 0, len(obsRows))
+	for _, o := range obsRows {
+		observations = append(observations, ScanObservationDetail{
+			EntityType: o.EntityType,
+			EntityKey:  o.EntityKey,
+			ChangeType: o.ChangeType,
+			Payload:    json.RawMessage(o.Payload),
+			ObservedAt: o.ObservedAt.Time,
+		})
+	}
+
+	return ScanDetailView{FlatScanView: head, Observations: observations}, nil
 }
 
 // ListByTenantFlat returns the tenant scan feed as a flat, newest-first, paginated

--- a/internal/store/observations.sql.go
+++ b/internal/store/observations.sql.go
@@ -141,12 +141,19 @@ const observationsListByScan = `-- name: ObservationsListByScan :many
 SELECT id, tenant_id, domain_id, domain_uid, domain_name, scan_id, entity_type, entity_key, change_type, payload, observed_at
 FROM domain_observations
 WHERE scan_id = $1
+  AND tenant_id = $2
 ORDER BY entity_type, entity_key
 `
 
-// All observations emitted during a single scan (scan-diff feature).
-func (q *Queries) ObservationsListByScan(ctx context.Context, scanID pgtype.Int8) ([]DomainObservations, error) {
-	rows, err := q.db.Query(ctx, observationsListByScan, scanID)
+type ObservationsListByScanParams struct {
+	ScanID   pgtype.Int8 `json:"scan_id"`
+	TenantID int32       `json:"tenant_id"`
+}
+
+// All observations emitted during a single scan (scan-diff detail), tenant-scoped
+// for defense-in-depth even though callers verify scan ownership first.
+func (q *Queries) ObservationsListByScan(ctx context.Context, arg ObservationsListByScanParams) ([]DomainObservations, error) {
+	rows, err := q.db.Query(ctx, observationsListByScan, arg.ScanID, arg.TenantID)
 	if err != nil {
 		return nil, err
 	}
@@ -406,6 +413,92 @@ func (q *Queries) ScansCreate(ctx context.Context, arg ScansCreateParams) (Scans
 		&i.ParentScanID,
 		&i.Source,
 		&i.StartedAt,
+	)
+	return i, err
+}
+
+const scansGetByTenantUID = `-- name: ScansGetByTenantUID :one
+WITH target_scan AS (
+    SELECT s.id, s.uid, s.domain_uid, s.domain_name, s.source,
+           s.started_at, s.parent_scan_id
+    FROM scans s
+    WHERE s.tenant_id = $1
+      AND s.uid = $2
+),
+change_counts AS (
+    SELECT o.scan_id, o.entity_type, o.change_type, count(*) AS n
+    FROM domain_observations o
+    WHERE o.scan_id IN (SELECT id FROM target_scan)
+    GROUP BY o.scan_id, o.entity_type, o.change_type
+),
+per_scan AS (
+    SELECT scan_id,
+           COALESCE(sum(n) FILTER (WHERE change_type = 'created'), 0) AS created,
+           COALESCE(sum(n) FILTER (WHERE change_type = 'updated'), 0) AS updated,
+           COALESCE(sum(n) FILTER (WHERE change_type = 'deleted'), 0) AS deleted,
+           jsonb_agg(jsonb_build_object(
+               'entity_type', entity_type,
+               'change_type', change_type,
+               'count', n) ORDER BY entity_type, change_type) AS breakdown
+    FROM change_counts
+    GROUP BY scan_id
+)
+SELECT t.id                           AS scan_id,
+       t.uid                          AS scan_uid,
+       t.domain_uid,
+       t.domain_name,
+       t.source,
+       t.started_at,
+       p.uid                          AS parent_scan_uid,
+       COALESCE(ps.created, 0)::int   AS created_count,
+       COALESCE(ps.updated, 0)::int   AS updated_count,
+       COALESCE(ps.deleted, 0)::int   AS deleted_count,
+       COALESCE(ps.breakdown, '[]'::jsonb) AS breakdown
+FROM target_scan t
+         LEFT JOIN scans p ON p.id = t.parent_scan_id
+         LEFT JOIN per_scan ps ON ps.scan_id = t.id
+`
+
+type ScansGetByTenantUIDParams struct {
+	TenantID int32  `json:"tenant_id"`
+	Uid      string `json:"uid"`
+}
+
+type ScansGetByTenantUIDRow struct {
+	ScanID        int64              `json:"scan_id"`
+	ScanUid       string             `json:"scan_uid"`
+	DomainUid     string             `json:"domain_uid"`
+	DomainName    string             `json:"domain_name"`
+	Source        DomainSource       `json:"source"`
+	StartedAt     pgtype.Timestamptz `json:"started_at"`
+	ParentScanUid pgtype.Text        `json:"parent_scan_uid"`
+	CreatedCount  int32              `json:"created_count"`
+	UpdatedCount  int32              `json:"updated_count"`
+	DeletedCount  int32              `json:"deleted_count"`
+	Breakdown     []byte             `json:"breakdown"`
+}
+
+// Single scan by (tenant_id, uid) with its per-scan change aggregate, for the
+// scan-detail API. The (tenant_id, uid) WHERE gate is the isolation boundary: a
+// cross-tenant or unknown uid returns no rows (pgx.ErrNoRows). Mirrors the
+// aggregate columns of ScansListByTenant and additionally returns the internal
+// scan id so the caller can fetch this scan's observations. Observation
+// aggregation is bounded to the single target scan and rides idx_obs_scan.
+func (q *Queries) ScansGetByTenantUID(ctx context.Context, arg ScansGetByTenantUIDParams) (ScansGetByTenantUIDRow, error) {
+	row := q.db.QueryRow(ctx, scansGetByTenantUID, arg.TenantID, arg.Uid)
+	var i ScansGetByTenantUIDRow
+	err := row.Scan(
+		&i.ScanID,
+		&i.ScanUid,
+		&i.DomainUid,
+		&i.DomainName,
+		&i.Source,
+		&i.StartedAt,
+		&i.ParentScanUid,
+		&i.CreatedCount,
+		&i.UpdatedCount,
+		&i.DeletedCount,
+		&i.Breakdown,
 	)
 	return i, err
 }

--- a/sql/queries/observations.sql
+++ b/sql/queries/observations.sql
@@ -89,6 +89,53 @@ FROM target_scans t
          LEFT JOIN per_scan ps ON ps.scan_id = t.id
 ORDER BY t.started_at DESC, t.id DESC;
 
+-- name: ScansGetByTenantUID :one
+-- Single scan by (tenant_id, uid) with its per-scan change aggregate, for the
+-- scan-detail API. The (tenant_id, uid) WHERE gate is the isolation boundary: a
+-- cross-tenant or unknown uid returns no rows (pgx.ErrNoRows). Mirrors the
+-- aggregate columns of ScansListByTenant and additionally returns the internal
+-- scan id so the caller can fetch this scan's observations. Observation
+-- aggregation is bounded to the single target scan and rides idx_obs_scan.
+WITH target_scan AS (
+    SELECT s.id, s.uid, s.domain_uid, s.domain_name, s.source,
+           s.started_at, s.parent_scan_id
+    FROM scans s
+    WHERE s.tenant_id = @tenant_id
+      AND s.uid = @uid
+),
+change_counts AS (
+    SELECT o.scan_id, o.entity_type, o.change_type, count(*) AS n
+    FROM domain_observations o
+    WHERE o.scan_id IN (SELECT id FROM target_scan)
+    GROUP BY o.scan_id, o.entity_type, o.change_type
+),
+per_scan AS (
+    SELECT scan_id,
+           COALESCE(sum(n) FILTER (WHERE change_type = 'created'), 0) AS created,
+           COALESCE(sum(n) FILTER (WHERE change_type = 'updated'), 0) AS updated,
+           COALESCE(sum(n) FILTER (WHERE change_type = 'deleted'), 0) AS deleted,
+           jsonb_agg(jsonb_build_object(
+               'entity_type', entity_type,
+               'change_type', change_type,
+               'count', n) ORDER BY entity_type, change_type) AS breakdown
+    FROM change_counts
+    GROUP BY scan_id
+)
+SELECT t.id                           AS scan_id,
+       t.uid                          AS scan_uid,
+       t.domain_uid,
+       t.domain_name,
+       t.source,
+       t.started_at,
+       p.uid                          AS parent_scan_uid,
+       COALESCE(ps.created, 0)::int   AS created_count,
+       COALESCE(ps.updated, 0)::int   AS updated_count,
+       COALESCE(ps.deleted, 0)::int   AS deleted_count,
+       COALESCE(ps.breakdown, '[]'::jsonb) AS breakdown
+FROM target_scan t
+         LEFT JOIN scans p ON p.id = t.parent_scan_id
+         LEFT JOIN per_scan ps ON ps.scan_id = t.id;
+
 -- name: ObservationsCreate :one
 -- Append one change to the observation log.
 INSERT INTO domain_observations (tenant_id, domain_id, domain_uid, domain_name, scan_id, entity_type, entity_key,
@@ -131,10 +178,12 @@ WHERE tenant_id = $1
 ORDER BY observed_at DESC;
 
 -- name: ObservationsListByScan :many
--- All observations emitted during a single scan (scan-diff feature).
+-- All observations emitted during a single scan (scan-diff detail), tenant-scoped
+-- for defense-in-depth even though callers verify scan ownership first.
 SELECT id, tenant_id, domain_id, domain_uid, domain_name, scan_id, entity_type, entity_key, change_type, payload, observed_at
 FROM domain_observations
-WHERE scan_id = $1
+WHERE scan_id = sqlc.arg(scan_id)
+  AND tenant_id = sqlc.arg(tenant_id)
 ORDER BY entity_type, entity_key;
 
 -- name: ObservationsListTimelineByTenantDomainName :many


### PR DESCRIPTION
Closes #34.

## Context

The tenant-wide `GET /api/scans` feed already shipped in #40. This PR completes issue #34's **optional** item — a single-scan detail endpoint — and backfills two list-filter test gaps.

## Changes

**`GET /api/scans/{uid}`** — returns one scan's change aggregate (same shape as a feed row) plus its full per-observation diff detail.

- **SQL**: new `ScansGetByTenantUID :one` (single scan by `(tenant_id, uid)`, reusing the list feed's `change_counts`/`per_scan` CTEs and returning the internal id). `ObservationsListByScan` is now `(scan_id, tenant_id)`-scoped for defense-in-depth (it had no callers).
- **Service**: `ScansService.GetByUID` + `ScanDetailView`/`ScanObservationDetail`. The scan header is derived through the existing `mapScanRow`/`flatScanView` path, so the list and detail endpoints can't drift on `baseline/clean/changed` state. `pgx.ErrNoRows` → `ErrNotFound`.
- **HTTP**: `handleScanDetail` registered as `get_scan` under `apiAuth`; `ErrNotFound` → 404.
- **Tests**: through the full chi→Huma→apiAuth path — diff happy-path, cross-tenant 404, unknown-uid 404, missing-key 401, plus the previously-missing `changed_only` and `q` list filters.

## Notes

- No migration. The detail query fetches one scan by indexed unique `uid` and its observations via `scan_id` (rides `idx_obs_scan`) — no full-scan of `domain_observations`.
- Tenant isolation is the SQL `WHERE tenant_id` gate, asserted over HTTP (tenant A gets 404 for tenant B's real scan uid).
- `op`/`class` glyph fields are intentionally excluded from the machine-facing diff; `change_type` conveys the change kind.