### PR TITLE
Implement CNAME dangling / subdomain-takeover assessor (#30)

### DIFF
--- a/assets/migrations/00018_cname_finding_constraints.sql
+++ b/assets/migrations/00018_cname_finding_constraints.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Enable upsert-dedup for the CNAME findings tables, which (like the old
+-- dnssec_findings table) shipped without the UNIQUE constraint every other
+-- findings table relies on for ON CONFLICT.
+ALTER TABLE dangling_cname_findings
+    ADD CONSTRAINT dangling_cname_findings_domain_id_target_domain_key UNIQUE (domain_id, target_domain);
+
+ALTER TABLE cname_redirection_findings
+    ADD CONSTRAINT cname_redirection_findings_domain_id_issue_type_key UNIQUE (domain_id, issue_type);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE cname_redirection_findings
+    DROP CONSTRAINT IF EXISTS cname_redirection_findings_domain_id_issue_type_key;
+ALTER TABLE dangling_cname_findings
+    DROP CONSTRAINT IF EXISTS dangling_cname_findings_domain_id_target_domain_key;
+-- +goose StatementEnd

--- a/internal/assessor/assess_cname.go
+++ b/internal/assessor/assess_cname.go
@@ -1,0 +1,308 @@
+package assessor
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"sync/atomic"
+
+	"github.com/danielmichaels/gecko/internal/dnsclient"
+	"github.com/danielmichaels/gecko/internal/observer"
+	"github.com/danielmichaels/gecko/internal/store"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/miekg/dns"
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	IssuePointsToIP = "points_to_ip"
+	IssueLongChain  = "long_chain"
+	IssueCNAMELoop  = "cname_loop"
+)
+
+const (
+	// probeConcurrency bounds concurrent outbound probes within a single assess
+	// job. The fleet-wide bound is the queue_assessor MaxWorkers cap; this only
+	// limits fan-out across one domain's CNAME targets.
+	probeConcurrency = 4
+	// longChainThreshold and maxChainDepth bound CNAME chain-hygiene analysis.
+	longChainThreshold = 8
+	maxChainDepth      = 16
+)
+
+// danglingVerdict is the outcome of classifying one CNAME target.
+type danglingVerdict struct {
+	severity         store.FindingSeverity
+	status           store.FindingStatus
+	provider         string
+	details          string
+	takeoverPossible bool
+	finding          bool
+}
+
+// classifyDangling applies the conservative false-positive policy to one CNAME
+// target. A target pointing at a takeover-able provider is high/takeover only when
+// the takeover is confirmed (the provider's unclaimed-resource error body, or the
+// target failing to resolve at all); a live page suppresses the finding. A target
+// that merely fails to resolve, with no takeover-able provider, is medium and not
+// flagged as takeover. Anything that resolves cleanly without a takeover signal,
+// or whose resolution is indeterminate (SERVFAIL/timeout), yields no finding.
+func classifyDangling(
+	res dnsclient.ResolutionStatus,
+	fp cnameFingerprint,
+	fpMatched bool,
+	probe ProbeResult,
+) danglingVerdict {
+	nonResolving := res == dnsclient.ResolutionEmpty
+
+	if fpMatched && fp.TakeoverPossible {
+		bodyConfirmed := probe.Reached && fp.ErrorBody != "" &&
+			strings.Contains(probe.Body, fp.ErrorBody)
+		switch {
+		case bodyConfirmed || nonResolving:
+			return danglingVerdict{
+				finding:          true,
+				severity:         store.FindingSeverityHigh,
+				status:           store.FindingStatusOpen,
+				takeoverPossible: true,
+				provider:         fp.Provider,
+				details: fmt.Sprintf(
+					"CNAME target points to %s and the resource appears unclaimed (subdomain takeover candidate)",
+					fp.Provider,
+				),
+			}
+		case probe.Reached && probe.StatusCode == 200:
+			return danglingVerdict{finding: false}
+		default:
+			return danglingVerdict{
+				finding:          true,
+				severity:         store.FindingSeverityMedium,
+				status:           store.FindingStatusOpen,
+				takeoverPossible: false,
+				provider:         fp.Provider,
+				details: fmt.Sprintf(
+					"CNAME target points to %s; takeover could not be confirmed",
+					fp.Provider,
+				),
+			}
+		}
+	}
+
+	if nonResolving {
+		v := danglingVerdict{
+			finding:          true,
+			severity:         store.FindingSeverityMedium,
+			status:           store.FindingStatusOpen,
+			takeoverPossible: false,
+			details:          "CNAME target does not resolve (NXDOMAIN)",
+		}
+		if fpMatched {
+			v.provider = fp.Provider
+		}
+		return v
+	}
+
+	return danglingVerdict{finding: false}
+}
+
+// AssessCNAMEDangling reads the domain's persisted CNAME records, re-resolves each
+// target live to detect non-resolving (NXDOMAIN) targets, fingerprints
+// takeover-able providers, and — for resolving takeover candidates — probes the
+// target over HTTP(S) to confirm or suppress the finding. It records dangling
+// findings and CNAME chain-hygiene findings with observations.
+func (a *Assessor) AssessCNAMEDangling(ctx context.Context, domainUID string) error {
+	domain, err := a.store.DomainsGetByIdentifier(ctx, store.DomainsGetByIdentifierParams{
+		Uid:      domainUID,
+		TenantID: pgtype.Int4{Int32: a.identity.TenantID, Valid: true},
+	})
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("domain %s not found in database", domainUID)
+		}
+		a.logger.ErrorContext(ctx, "Error looking up domain", "domain", domainUID, "error", err)
+		return err
+	}
+
+	records, err := a.store.RecordsGetCNAMEByDomainID(
+		ctx,
+		pgtype.Int4{Int32: domain.ID, Valid: true},
+	)
+	if err != nil {
+		a.logger.ErrorContext(ctx, "Failed to retrieve CNAME records", "error", err)
+		return err
+	}
+	if len(records) == 0 {
+		a.logger.InfoContext(ctx, "No CNAME records to assess", "domain", domain.Uid)
+		return nil
+	}
+
+	var danglingFound atomic.Int64
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(probeConcurrency)
+	for _, record := range records {
+		g.Go(func() error {
+			if a.assessCNAMETarget(gctx, domain.ID, record) {
+				danglingFound.Add(1)
+			}
+			return nil
+		})
+	}
+	_ = g.Wait()
+
+	a.logger.InfoContext(ctx, "assessed CNAME records",
+		"domain", domain.Uid,
+		"records", len(records),
+		"dangling_findings", danglingFound.Load())
+	return nil
+}
+
+// assessCNAMETarget evaluates a single CNAME record for both the dangling/takeover
+// risk and chain-hygiene issues, returning whether a dangling finding was
+// recorded. Per-target failures are logged, not propagated, so one bad target does
+// not abort the others.
+func (a *Assessor) assessCNAMETarget(
+	ctx context.Context,
+	domainID int32,
+	record store.CnameRecords,
+) bool {
+	target := record.Target
+	_, res := a.dnsClient.LookupWithStatus(target, dns.TypeA)
+
+	fp, fpMatched := matchFingerprint(target)
+	var probe ProbeResult
+	if fpMatched && fp.TakeoverPossible && res == dnsclient.ResolutionData {
+		probe = a.prober.Probe(ctx, target)
+	}
+
+	var recorded bool
+	if verdict := classifyDangling(res, fp, fpMatched, probe); verdict.finding {
+		recorded = a.recordDanglingFinding(ctx, domainID, target, verdict)
+	}
+
+	a.assessCNAMEChain(ctx, domainID, record)
+	return recorded
+}
+
+func (a *Assessor) recordDanglingFinding(
+	ctx context.Context,
+	domainID int32,
+	target string,
+	verdict danglingVerdict,
+) bool {
+	_, err := a.store.StoreDanglingCnameFinding(ctx, store.StoreDanglingCnameFindingParams{
+		DomainID:         pgtype.Int4{Int32: domainID, Valid: true},
+		Severity:         verdict.severity,
+		Status:           verdict.status,
+		TargetDomain:     target,
+		ServiceProvider:  pgtype.Text{String: verdict.provider, Valid: verdict.provider != ""},
+		TakeoverPossible: verdict.takeoverPossible,
+		Details:          pgtype.Text{String: verdict.details, Valid: verdict.details != ""},
+	})
+	if err != nil {
+		a.logger.ErrorContext(ctx, "Failed to store dangling CNAME finding",
+			"target", target, "error", err)
+		return false
+	}
+	payload := observer.PayloadJSON(map[string]any{
+		"target_domain":     target,
+		"severity":          string(verdict.severity),
+		"status":            string(verdict.status),
+		"service_provider":  verdict.provider,
+		"takeover_possible": verdict.takeoverPossible,
+	})
+	if oErr := observer.New(a.store).RecordFindingChange(
+		ctx, a.identity, observer.EntityCNAMEDanglingFinding, target, payload,
+	); oErr != nil {
+		a.logger.WarnContext(ctx, "failed to emit dangling CNAME finding observation",
+			"target", target, "error", oErr)
+	}
+	return true
+}
+
+// assessCNAMEChain flags CNAME chain-hygiene issues: a target that is an IP
+// literal, an over-long chain, or a loop.
+func (a *Assessor) assessCNAMEChain(
+	ctx context.Context,
+	domainID int32,
+	record store.CnameRecords,
+) {
+	target := strings.TrimSuffix(record.Target, ".")
+	if net.ParseIP(target) != nil {
+		a.recordRedirectionFinding(ctx, domainID, record, IssuePointsToIP,
+			store.FindingSeverityMedium, 1,
+			fmt.Sprintf("CNAME target %q is an IP address; a CNAME must point to a name", target))
+		return
+	}
+
+	length, looped := a.walkCNAMEChain(record.Target)
+	switch {
+	case looped:
+		a.recordRedirectionFinding(ctx, domainID, record, IssueCNAMELoop,
+			store.FindingSeverityMedium, length, "CNAME chain forms a loop")
+	case length >= longChainThreshold:
+		a.recordRedirectionFinding(ctx, domainID, record, IssueLongChain,
+			store.FindingSeverityLow, length,
+			fmt.Sprintf("CNAME chain is %d hops long", length))
+	}
+}
+
+// walkCNAMEChain follows the CNAME chain from start, returning the hop count and
+// whether a loop was detected. The walk is bounded by maxChainDepth.
+func (a *Assessor) walkCNAMEChain(start string) (int, bool) {
+	seen := make(map[string]bool)
+	current := start
+	for length := 1; length <= maxChainDepth; length++ {
+		key := strings.ToLower(strings.TrimSuffix(current, "."))
+		if seen[key] {
+			return length, true
+		}
+		seen[key] = true
+		next, ok := a.dnsClient.LookupCNAME(current)
+		if !ok || len(next) == 0 {
+			return length, false
+		}
+		current = next[0]
+	}
+	return maxChainDepth, false
+}
+
+func (a *Assessor) recordRedirectionFinding(
+	ctx context.Context,
+	domainID int32,
+	record store.CnameRecords,
+	issueType string,
+	severity store.FindingSeverity,
+	chainLength int,
+	details string,
+) {
+	_, err := a.store.StoreCnameRedirectionFinding(ctx, store.StoreCnameRedirectionFindingParams{
+		DomainID:      pgtype.Int4{Int32: domainID, Valid: true},
+		CnameRecordID: pgtype.Int4{Int32: record.ID, Valid: true},
+		Severity:      severity,
+		Status:        store.FindingStatusOpen,
+		IssueType:     issueType,
+		ChainLength:   pgtype.Int4{Int32: int32(chainLength), Valid: true},
+		Details:       pgtype.Text{String: details, Valid: details != ""},
+	})
+	if err != nil {
+		a.logger.ErrorContext(ctx, "Failed to store CNAME redirection finding",
+			"issue_type", issueType, "error", err)
+		return
+	}
+	payload := observer.PayloadJSON(map[string]any{
+		"issue_type":   issueType,
+		"severity":     string(severity),
+		"status":       string(store.FindingStatusOpen),
+		"chain_length": chainLength,
+		"details":      details,
+	})
+	if oErr := observer.New(a.store).RecordFindingChange(
+		ctx, a.identity, observer.EntityCNAMERedirectionFinding, issueType, payload,
+	); oErr != nil {
+		a.logger.WarnContext(ctx, "failed to emit CNAME redirection finding observation",
+			"issue_type", issueType, "error", oErr)
+	}
+}

--- a/internal/assessor/assess_cname_test.go
+++ b/internal/assessor/assess_cname_test.go
@@ -1,0 +1,262 @@
+package assessor
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/danielmichaels/gecko/internal/dnsclient"
+	"github.com/danielmichaels/gecko/internal/observer"
+	"github.com/danielmichaels/gecko/internal/store"
+	"github.com/danielmichaels/gecko/internal/testhelpers"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/miekg/dns"
+)
+
+// fakeProber returns programmed probe results keyed by target host so the dangling
+// assessor's HTTP path is exercised without real egress.
+type fakeProber struct {
+	results map[string]ProbeResult
+}
+
+func (f fakeProber) Probe(_ context.Context, target string) ProbeResult {
+	if r, ok := f.results[strings.TrimSuffix(target, ".")]; ok {
+		return r
+	}
+	return ProbeResult{Reached: false}
+}
+
+func danglingByTarget(
+	findings []store.DanglingCnameFindings,
+	target string,
+) (store.DanglingCnameFindings, bool) {
+	for _, f := range findings {
+		if f.TargetDomain == target {
+			return f, true
+		}
+	}
+	return store.DanglingCnameFindings{}, false
+}
+
+func TestAssessCNAMEDangling(t *testing.T) {
+	ctx := context.Background()
+	pgContainer, err := testhelpers.CreatePostgresContainer(ctx)
+	if err != nil {
+		t.Fatalf("Failed to create postgres container: %v", err)
+	}
+	defer pgContainer.Close(ctx)
+
+	mockServer, err := testhelpers.NewMockDNSServer()
+	if err != nil {
+		t.Fatalf("Failed to create mock DNS server: %v", err)
+	}
+	if err := mockServer.Start(); err != nil {
+		t.Fatalf("Failed to start mock DNS server: %v", err)
+	}
+	defer func() { _ = mockServer.Stop() }()
+
+	dnsClient := dnsclient.New(
+		dnsclient.WithServers([]string{mockServer.ListenAddr}),
+		dnsclient.WithLogger(testhelpers.TestLogger),
+	)
+
+	newDomain := func(t *testing.T, name string) store.DomainsCreateRow {
+		t.Helper()
+		d, err := pgContainer.Queries.DomainsCreate(ctx, store.DomainsCreateParams{
+			TenantID:   pgtype.Int4{Int32: 1, Valid: true},
+			Name:       name,
+			DomainType: store.DomainTypeTld,
+			Source:     store.DomainSourceUserSupplied,
+			Status:     store.DomainStatusActive,
+		})
+		if err != nil {
+			t.Fatalf("Failed to create domain %s: %v", name, err)
+		}
+		return d
+	}
+
+	seedCNAME := func(t *testing.T, domainID int32, target string) {
+		t.Helper()
+		if _, err := pgContainer.Queries.RecordsCreateCNAME(ctx, store.RecordsCreateCNAMEParams{
+			DomainID: pgtype.Int4{Int32: domainID, Valid: true},
+			Target:   target,
+		}); err != nil {
+			t.Fatalf("Failed to seed CNAME record: %v", err)
+		}
+	}
+
+	assess := func(t *testing.T, d store.DomainsCreateRow, prober HTTPProber) []store.DanglingCnameFindings {
+		t.Helper()
+		ident := observer.DomainIdentity{
+			TenantID:   1,
+			DomainID:   d.ID,
+			DomainUID:  d.Uid,
+			DomainName: d.Name,
+		}
+		a := NewAssessor(Config{
+			Store:      pgContainer.Queries,
+			Logger:     testhelpers.TestLogger,
+			DNSClient:  dnsClient,
+			HTTPProber: prober,
+			Identity:   ident,
+		})
+		if err := a.AssessCNAMEDangling(ctx, d.Uid); err != nil {
+			t.Fatalf("AssessCNAMEDangling failed: %v", err)
+		}
+		findings, err := pgContainer.Queries.AssessGetDanglingCnameFindingsByDomainUID(
+			ctx,
+			store.AssessGetDanglingCnameFindingsByDomainUIDParams{
+				Uid:      d.Uid,
+				TenantID: pgtype.Int4{Int32: 1, Valid: true},
+			},
+		)
+		if err != nil {
+			t.Fatalf("Failed to get dangling CNAME findings: %v", err)
+		}
+		return findings
+	}
+
+	t.Run("non-resolving target without fingerprint is medium, not takeover", func(t *testing.T) {
+		d := newDomain(t, "gone-target.test")
+		target := "removed.internal.test"
+		seedCNAME(t, d.ID, target)
+		t.Cleanup(func() { mockServer.ClearRecords() })
+
+		findings := assess(t, d, fakeProber{})
+		f, ok := danglingByTarget(findings, target)
+		if !ok {
+			t.Fatalf("expected a dangling finding for %s", target)
+		}
+		if f.Severity != store.FindingSeverityMedium {
+			t.Errorf("severity: got=%s want=medium", f.Severity)
+		}
+		if f.TakeoverPossible {
+			t.Error("did not expect takeover_possible for a bare non-resolving target")
+		}
+	})
+
+	t.Run("takeover provider with confirmed unclaimed page is high takeover", func(t *testing.T) {
+		d := newDomain(t, "takeover.test")
+		target := "victim-bucket.s3.amazonaws.com"
+		seedCNAME(t, d.ID, target)
+		if err := mockServer.AddRecord(target, dns.TypeA, 3600, "192.0.2.50"); err != nil {
+			t.Fatalf("add A record: %v", err)
+		}
+		t.Cleanup(func() { mockServer.ClearRecords() })
+
+		prober := fakeProber{results: map[string]ProbeResult{
+			target: {
+				Reached:    true,
+				StatusCode: 404,
+				Body:       "<Error><Code>NoSuchBucket</Code></Error>",
+			},
+		}}
+		findings := assess(t, d, prober)
+		f, ok := danglingByTarget(findings, target)
+		if !ok {
+			t.Fatalf("expected a dangling finding for %s", target)
+		}
+		if f.Severity != store.FindingSeverityHigh {
+			t.Errorf("severity: got=%s want=high", f.Severity)
+		}
+		if !f.TakeoverPossible {
+			t.Error("expected takeover_possible for a confirmed unclaimed bucket")
+		}
+		if f.ServiceProvider.String != "AWS S3" {
+			t.Errorf("provider: got=%q want=AWS S3", f.ServiceProvider.String)
+		}
+	})
+
+	t.Run("takeover provider serving a live page is suppressed", func(t *testing.T) {
+		d := newDomain(t, "live-bucket.test")
+		target := "live-bucket.s3.amazonaws.com"
+		seedCNAME(t, d.ID, target)
+		if err := mockServer.AddRecord(target, dns.TypeA, 3600, "192.0.2.60"); err != nil {
+			t.Fatalf("add A record: %v", err)
+		}
+		t.Cleanup(func() { mockServer.ClearRecords() })
+
+		prober := fakeProber{results: map[string]ProbeResult{
+			target: {Reached: true, StatusCode: 200, Body: "<html>real site</html>"},
+		}}
+		findings := assess(t, d, prober)
+		if _, ok := danglingByTarget(findings, target); ok {
+			t.Error("expected a live takeover-provider page to be suppressed")
+		}
+	})
+
+	t.Run("healthy resolving target without fingerprint yields no finding", func(t *testing.T) {
+		d := newDomain(t, "healthy.test")
+		target := "edge.example.test"
+		seedCNAME(t, d.ID, target)
+		if err := mockServer.AddRecord(target, dns.TypeA, 3600, "192.0.2.70"); err != nil {
+			t.Fatalf("add A record: %v", err)
+		}
+		t.Cleanup(func() { mockServer.ClearRecords() })
+
+		findings := assess(t, d, fakeProber{})
+		if _, ok := danglingByTarget(findings, target); ok {
+			t.Error("did not expect a finding for a healthy resolving target")
+		}
+	})
+
+	t.Run("CNAME pointing to an IP yields a points_to_ip redirection finding", func(t *testing.T) {
+		d := newDomain(t, "ip-target.test")
+		target := "192.0.2.99"
+		seedCNAME(t, d.ID, target)
+		t.Cleanup(func() { mockServer.ClearRecords() })
+
+		_ = assess(t, d, fakeProber{})
+		redir, err := pgContainer.Queries.AssessGetCnameRedirectionFindingsByDomainUID(
+			ctx,
+			store.AssessGetCnameRedirectionFindingsByDomainUIDParams{
+				Uid:      d.Uid,
+				TenantID: pgtype.Int4{Int32: 1, Valid: true},
+			},
+		)
+		if err != nil {
+			t.Fatalf("get redirection findings: %v", err)
+		}
+		var found bool
+		for _, f := range redir {
+			if f.IssueType == IssuePointsToIP {
+				found = true
+			}
+		}
+		if !found {
+			t.Error("expected a points_to_ip redirection finding")
+		}
+	})
+
+	t.Run("zero identity still writes findings without emitting observations", func(t *testing.T) {
+		d := newDomain(t, "no-identity.test")
+		target := "orphan.internal.test"
+		seedCNAME(t, d.ID, target)
+		t.Cleanup(func() { mockServer.ClearRecords() })
+
+		// TenantID set (so the tenant-scoped domain lookup succeeds) but DomainID
+		// left zero, so Recordable() is false and observation emission is skipped.
+		a := NewAssessor(Config{
+			Store:     pgContainer.Queries,
+			Logger:    testhelpers.TestLogger,
+			DNSClient: dnsClient,
+			Identity:  observer.DomainIdentity{TenantID: 1},
+		})
+		if err := a.AssessCNAMEDangling(ctx, d.Uid); err != nil {
+			t.Fatalf("AssessCNAMEDangling failed: %v", err)
+		}
+		findings, err := pgContainer.Queries.AssessGetDanglingCnameFindingsByDomainUID(
+			ctx,
+			store.AssessGetDanglingCnameFindingsByDomainUIDParams{
+				Uid:      d.Uid,
+				TenantID: pgtype.Int4{Int32: 1, Valid: true},
+			},
+		)
+		if err != nil {
+			t.Fatalf("get findings: %v", err)
+		}
+		if _, ok := danglingByTarget(findings, target); !ok {
+			t.Error("expected finding to be written even without a scan identity")
+		}
+	})
+}

--- a/internal/assessor/assess_email_security.go
+++ b/internal/assessor/assess_email_security.go
@@ -160,7 +160,7 @@ func (a *Assessor) assessDKIM(ctx context.Context, d assessData, selectors []str
 	defer func() { a.logger.DebugContext(ctx, "assess DKIM complete", "domain_id", d.domainID) }()
 
 	domain, err := a.store.DomainsGetByIdentifier(ctx, store.DomainsGetByIdentifierParams{
-		TenantID: pgtype.Int4{Int32: int32(1), Valid: true},
+		TenantID: pgtype.Int4{Int32: a.identity.TenantID, Valid: true},
 		ID:       int32(d.domainID),
 	})
 	if err != nil {
@@ -283,7 +283,7 @@ func (a *Assessor) assessDMARC(ctx context.Context, d assessData) error {
 	defer func() { a.logger.DebugContext(ctx, "assess DMARC complete", "domain_id", d.domainID) }()
 
 	domain, err := a.store.DomainsGetByIdentifier(ctx, store.DomainsGetByIdentifierParams{
-		TenantID: pgtype.Int4{Int32: int32(1), Valid: true},
+		TenantID: pgtype.Int4{Int32: a.identity.TenantID, Valid: true},
 		ID:       int32(d.domainID),
 	})
 	if err != nil {

--- a/internal/assessor/assess_email_security_test.go
+++ b/internal/assessor/assess_email_security_test.go
@@ -5,11 +5,74 @@ import (
 	"testing"
 
 	"github.com/danielmichaels/gecko/internal/dnsclient"
+	"github.com/danielmichaels/gecko/internal/observer"
 	"github.com/danielmichaels/gecko/internal/store"
 	"github.com/danielmichaels/gecko/internal/testhelpers"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/miekg/dns"
 )
+
+// TestAssessEmailSecurity_UsesIdentityTenant guards against the email-security
+// assessor looking up the domain under a hardcoded tenant: a domain owned by any
+// tenant other than the default must still be found via the scan identity's
+// tenant. Before the fix the DKIM/DMARC sub-assessors queried tenant_id=1 and this
+// failed with "get domain ... no rows".
+func TestAssessEmailSecurity_UsesIdentityTenant(t *testing.T) {
+	ctx := context.Background()
+	pgContainer, err := testhelpers.CreatePostgresContainer(ctx)
+	if err != nil {
+		t.Fatalf("Failed to create postgres container: %v", err)
+	}
+	defer pgContainer.Close(ctx)
+
+	mockServer, err := testhelpers.NewMockDNSServer()
+	if err != nil {
+		t.Fatalf("Failed to create mock DNS server: %v", err)
+	}
+	if err := mockServer.Start(); err != nil {
+		t.Fatalf("Failed to start mock DNS server: %v", err)
+	}
+	defer func() { _ = mockServer.Stop() }()
+
+	dnsClient := dnsclient.New(
+		dnsclient.WithServers([]string{mockServer.ListenAddr}),
+		dnsclient.WithLogger(testhelpers.TestLogger),
+	)
+
+	tenant, err := pgContainer.Queries.TenantCreate(ctx, "email-tenant-two")
+	if err != nil {
+		t.Fatalf("Failed to create tenant: %v", err)
+	}
+	if tenant.ID == 1 {
+		t.Fatalf("expected a non-default tenant id, got %d", tenant.ID)
+	}
+
+	domain, err := pgContainer.Queries.DomainsCreate(ctx, store.DomainsCreateParams{
+		TenantID:   pgtype.Int4{Int32: tenant.ID, Valid: true},
+		Name:       "tenant-two.example.test",
+		DomainType: store.DomainTypeTld,
+		Source:     store.DomainSourceUserSupplied,
+		Status:     store.DomainStatusActive,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create domain: %v", err)
+	}
+
+	a := NewAssessor(Config{
+		Store:     pgContainer.Queries,
+		Logger:    testhelpers.TestLogger,
+		DNSClient: dnsClient,
+		Identity: observer.DomainIdentity{
+			TenantID:   tenant.ID,
+			DomainID:   domain.ID,
+			DomainUID:  domain.Uid,
+			DomainName: domain.Name,
+		},
+	})
+	if err := a.AssessEmailSecurity(ctx, int(domain.ID)); err != nil {
+		t.Fatalf("AssessEmailSecurity for a non-default-tenant domain failed: %v", err)
+	}
+}
 
 func TestAssessEmailSecurity_SPFIssues(t *testing.T) {
 	ctx := context.Background()
@@ -244,6 +307,7 @@ func TestAssessEmailSecurity_DKIM(t *testing.T) {
 		Store:     pgContainer.Queries,
 		Logger:    testhelpers.TestLogger,
 		DNSClient: dnsClient,
+		Identity:  observer.DomainIdentity{TenantID: 1},
 	})
 
 	tests := []struct {
@@ -470,6 +534,7 @@ func TestAssessEmailSecurity_DMARC(t *testing.T) {
 		Store:     pgContainer.Queries,
 		Logger:    testhelpers.TestLogger,
 		DNSClient: dnsClient,
+		Identity:  observer.DomainIdentity{TenantID: 1},
 	})
 
 	tests := []struct {

--- a/internal/assessor/asssessor.go
+++ b/internal/assessor/asssessor.go
@@ -16,6 +16,9 @@ type Config struct {
 	Logger    *slog.Logger
 	Store     *store.Queries
 	DNSClient dnsclient.Resolver
+	// HTTPProber probes CNAME targets for the dangling/takeover assessor. Left nil
+	// outside tests; NewAssessor supplies the default outbound prober.
+	HTTPProber HTTPProber
 	// Identity is the scan identity used to stamp observations. Left zero in unit
 	// tests (which exercise finding logic without a scan); emission is skipped then.
 	Identity observer.DomainIdentity
@@ -25,6 +28,7 @@ type Assessor struct {
 	logger    *slog.Logger
 	store     *store.Queries
 	dnsClient dnsclient.Resolver
+	prober    HTTPProber
 	identity  observer.DomainIdentity
 }
 
@@ -39,10 +43,16 @@ func NewAssessor(cfg Config) *Assessor {
 		dnsClient = dnsclient.New()
 	}
 
+	prober := cfg.HTTPProber
+	if prober == nil {
+		prober = newHTTPProber()
+	}
+
 	return &Assessor{
 		store:     cfg.Store,
 		logger:    logger,
 		dnsClient: dnsClient,
+		prober:    prober,
 		identity:  cfg.Identity,
 	}
 }

--- a/internal/assessor/cname_classify_test.go
+++ b/internal/assessor/cname_classify_test.go
@@ -1,0 +1,123 @@
+package assessor
+
+import (
+	"testing"
+
+	"github.com/danielmichaels/gecko/internal/dnsclient"
+	"github.com/danielmichaels/gecko/internal/store"
+)
+
+func TestClassifyDangling(t *testing.T) {
+	takeoverFP := cnameFingerprint{
+		Suffix:           ".s3.amazonaws.com",
+		Provider:         "AWS S3",
+		ErrorBody:        "NoSuchBucket",
+		TakeoverPossible: true,
+	}
+	benignFP := cnameFingerprint{
+		Suffix:           ".myshopify.com",
+		Provider:         "Shopify",
+		TakeoverPossible: false,
+	}
+
+	tests := []struct {
+		name         string
+		res          dnsclient.ResolutionStatus
+		fp           cnameFingerprint
+		fpMatched    bool
+		probe        ProbeResult
+		wantFinding  bool
+		wantSeverity store.FindingSeverity
+		wantTakeover bool
+		wantProvider string
+	}{
+		{
+			name:      "takeover provider with confirmed error body is high takeover",
+			res:       dnsclient.ResolutionData,
+			fp:        takeoverFP,
+			fpMatched: true,
+			probe: ProbeResult{
+				Reached:    true,
+				StatusCode: 404,
+				Body:       "<Error>NoSuchBucket</Error>",
+			},
+			wantFinding:  true,
+			wantSeverity: store.FindingSeverityHigh,
+			wantTakeover: true,
+			wantProvider: "AWS S3",
+		},
+		{
+			name:         "takeover provider that does not resolve is high takeover",
+			res:          dnsclient.ResolutionEmpty,
+			fp:           takeoverFP,
+			fpMatched:    true,
+			probe:        ProbeResult{Reached: false},
+			wantFinding:  true,
+			wantSeverity: store.FindingSeverityHigh,
+			wantTakeover: true,
+			wantProvider: "AWS S3",
+		},
+		{
+			name:        "takeover provider serving a live page is suppressed",
+			res:         dnsclient.ResolutionData,
+			fp:          takeoverFP,
+			fpMatched:   true,
+			probe:       ProbeResult{Reached: true, StatusCode: 200, Body: "<html>welcome</html>"},
+			wantFinding: false,
+		},
+		{
+			name:         "non-resolving target without fingerprint is medium not takeover",
+			res:          dnsclient.ResolutionEmpty,
+			fpMatched:    false,
+			wantFinding:  true,
+			wantSeverity: store.FindingSeverityMedium,
+			wantTakeover: false,
+		},
+		{
+			name:         "non-resolving benign provider is medium with provider, not takeover",
+			res:          dnsclient.ResolutionEmpty,
+			fp:           benignFP,
+			fpMatched:    true,
+			wantFinding:  true,
+			wantSeverity: store.FindingSeverityMedium,
+			wantTakeover: false,
+			wantProvider: "Shopify",
+		},
+		{
+			name:        "healthy resolving target without fingerprint yields no finding",
+			res:         dnsclient.ResolutionData,
+			fpMatched:   false,
+			wantFinding: false,
+		},
+		{
+			name:        "indeterminate resolution is not acted on",
+			res:         dnsclient.ResolutionIndeterminate,
+			fpMatched:   false,
+			wantFinding: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyDangling(tt.res, tt.fp, tt.fpMatched, tt.probe)
+			if got.finding != tt.wantFinding {
+				t.Fatalf("finding: got=%v want=%v", got.finding, tt.wantFinding)
+			}
+			if !tt.wantFinding {
+				return
+			}
+			if got.severity != tt.wantSeverity {
+				t.Errorf("severity: got=%s want=%s", got.severity, tt.wantSeverity)
+			}
+			if got.takeoverPossible != tt.wantTakeover {
+				t.Errorf("takeover: got=%v want=%v", got.takeoverPossible, tt.wantTakeover)
+			}
+			if got.provider != tt.wantProvider {
+				t.Errorf("provider: got=%q want=%q", got.provider, tt.wantProvider)
+			}
+			if got.status != store.FindingStatusOpen {
+				t.Errorf("status: got=%s want=open", got.status)
+			}
+		})
+	}
+}

--- a/internal/assessor/cname_fingerprints.go
+++ b/internal/assessor/cname_fingerprints.go
@@ -1,0 +1,133 @@
+package assessor
+
+import "strings"
+
+// cnameFingerprint maps a CNAME target suffix to the third-party service that
+// serves it. TakeoverPossible marks providers where an unclaimed resource can be
+// registered by an attacker (the subdomain-takeover risk); ErrorBody is the
+// response-body marker the HTTP prober looks for to confirm the resource is
+// actually unclaimed, used to separate a real takeover candidate from a live site.
+type cnameFingerprint struct {
+	Suffix           string
+	Provider         string
+	ErrorBody        string
+	TakeoverPossible bool
+}
+
+// cnameFingerprints is a deliberately small, high-confidence catalogue seeded from
+// the well-known can-i-take-over-xyz entries. It is hand-maintained rather than
+// vendored: the long tail of providers needs per-provider HTTP body matching to be
+// meaningful, so we only carry entries we can act on conservatively.
+var cnameFingerprints = []cnameFingerprint{
+	{
+		Suffix:           ".s3.amazonaws.com",
+		Provider:         "AWS S3",
+		ErrorBody:        "NoSuchBucket",
+		TakeoverPossible: true,
+	},
+	{Suffix: ".s3-website", Provider: "AWS S3", ErrorBody: "NoSuchBucket", TakeoverPossible: true},
+	{
+		Suffix:           ".github.io",
+		Provider:         "GitHub Pages",
+		ErrorBody:        "There isn't a GitHub Pages site here.",
+		TakeoverPossible: true,
+	},
+	{
+		Suffix:           ".herokuapp.com",
+		Provider:         "Heroku",
+		ErrorBody:        "No such app",
+		TakeoverPossible: true,
+	},
+	{
+		Suffix:           ".herokudns.com",
+		Provider:         "Heroku",
+		ErrorBody:        "No such app",
+		TakeoverPossible: true,
+	},
+	{Suffix: ".cloudapp.net", Provider: "Microsoft Azure", ErrorBody: "", TakeoverPossible: true},
+	{
+		Suffix:           ".cloudapp.azure.com",
+		Provider:         "Microsoft Azure",
+		ErrorBody:        "",
+		TakeoverPossible: true,
+	},
+	{
+		Suffix:           ".azurewebsites.net",
+		Provider:         "Microsoft Azure",
+		ErrorBody:        "",
+		TakeoverPossible: true,
+	},
+	{
+		Suffix:           ".trafficmanager.net",
+		Provider:         "Microsoft Azure",
+		ErrorBody:        "",
+		TakeoverPossible: true,
+	},
+	{
+		Suffix:           ".blob.core.windows.net",
+		Provider:         "Microsoft Azure",
+		ErrorBody:        "",
+		TakeoverPossible: true,
+	},
+	{
+		Suffix:           ".fastly.net",
+		Provider:         "Fastly",
+		ErrorBody:        "Fastly error: unknown domain",
+		TakeoverPossible: true,
+	},
+	{
+		Suffix:           ".surge.sh",
+		Provider:         "Surge.sh",
+		ErrorBody:        "project not found",
+		TakeoverPossible: true,
+	},
+	{
+		Suffix:           ".bitbucket.io",
+		Provider:         "Bitbucket",
+		ErrorBody:        "Repository not found",
+		TakeoverPossible: true,
+	},
+	{
+		Suffix:           ".pantheonsite.io",
+		Provider:         "Pantheon",
+		ErrorBody:        "The gods are wise, but do not know of the site which you seek.",
+		TakeoverPossible: true,
+	},
+	{
+		Suffix:           ".ghost.io",
+		Provider:         "Ghost",
+		ErrorBody:        "The thing you were looking for is no longer here, or never was",
+		TakeoverPossible: true,
+	},
+	{
+		Suffix:           ".domains.tumblr.com",
+		Provider:         "Tumblr",
+		ErrorBody:        "Whatever you were looking for doesn't currently exist at this address.",
+		TakeoverPossible: true,
+	},
+	{
+		Suffix:           ".myshopify.com",
+		Provider:         "Shopify",
+		ErrorBody:        "Sorry, this shop is currently unavailable.",
+		TakeoverPossible: false,
+	},
+	{
+		Suffix:           ".zendesk.com",
+		Provider:         "Zendesk",
+		ErrorBody:        "Help Center Closed",
+		TakeoverPossible: false,
+	},
+}
+
+// matchFingerprint returns the first catalogue entry whose suffix the CNAME target
+// ends with, after normalising case and any trailing dot. The catalogue is small
+// enough that a linear scan is the simplest correct approach.
+func matchFingerprint(target string) (cnameFingerprint, bool) {
+	normalized := strings.ToLower(strings.TrimSuffix(target, "."))
+	for _, fp := range cnameFingerprints {
+		if strings.Contains(normalized, fp.Suffix) {
+			return fp, true
+		}
+	}
+	return cnameFingerprint{}, false
+}

--- a/internal/assessor/prober.go
+++ b/internal/assessor/prober.go
@@ -1,0 +1,73 @@
+package assessor
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	probeTimeout    = 5 * time.Second
+	probeBodyMaxLen = 8 << 10
+)
+
+// ProbeResult is the outcome of an HTTP/HTTPS probe of a CNAME target. Reached is
+// false when no HTTP response could be obtained (connection refused, DNS failure,
+// timeout) — itself a strong "unclaimed resource" signal for a known provider.
+type ProbeResult struct {
+	Body       string
+	StatusCode int
+	Reached    bool
+}
+
+// HTTPProber probes a CNAME target over HTTP(S). It is an interface so the
+// assessor can be unit-tested with a deterministic fake instead of real egress.
+type HTTPProber interface {
+	Probe(ctx context.Context, target string) ProbeResult
+}
+
+type httpProber struct {
+	client *http.Client
+}
+
+// newHTTPProber builds the default prober: a short timeout and redirects stopped
+// at the first hop, so the immediate status/body of the target is observed rather
+// than wherever a takeover landing page forwards to.
+func newHTTPProber() *httpProber {
+	return &httpProber{
+		client: &http.Client{
+			Timeout: probeTimeout,
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+	}
+}
+
+// Probe tries HTTPS then HTTP, returning the first response it reaches. A bounded
+// body prefix is read so a large landing page cannot exhaust memory.
+func (p *httpProber) Probe(ctx context.Context, target string) ProbeResult {
+	host := strings.TrimSuffix(target, ".")
+	for _, scheme := range []string{"https://", "http://"} {
+		if res, ok := p.do(ctx, scheme+host); ok {
+			return res
+		}
+	}
+	return ProbeResult{Reached: false}
+}
+
+func (p *httpProber) do(ctx context.Context, url string) (ProbeResult, bool) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return ProbeResult{}, false
+	}
+	res, err := p.client.Do(req)
+	if err != nil {
+		return ProbeResult{}, false
+	}
+	defer func() { _ = res.Body.Close() }()
+	body, _ := io.ReadAll(io.LimitReader(res.Body, probeBodyMaxLen))
+	return ProbeResult{Reached: true, StatusCode: res.StatusCode, Body: string(body)}, true
+}

--- a/internal/jobs/assess_jobs.go
+++ b/internal/jobs/assess_jobs.go
@@ -39,19 +39,26 @@ func (w *AssessCNAMEDanglingWorker) Work(
 	job *river.Job[AssessCNAMEDanglingArgs],
 ) error {
 	ctx = tracing.WithNewTraceID(ctx, false)
-	w.Logger.InfoContext(ctx, "assess CNAME started", "domain", job.Args.DomainName)
-	_ = assessor.NewAssessor(assessor.Config{
+	start := time.Now()
+	w.Logger.InfoContext(ctx, "assess CNAME started", "domain", job.Args.DomainUID)
+	a := assessor.NewAssessor(assessor.Config{
 		Logger:    &w.Logger,
 		Store:     w.Store,
 		DNSClient: w.Resolver,
+		Identity:  job.Args.Identity(),
 	})
-	/* todo:
-	- cloud provider checks
-	- http/https checks
-	- wildcard detection?
-	- api checks?
-	- custom error page detection
-	*/
+	if err := a.AssessCNAMEDangling(ctx, job.Args.DomainUID); err != nil {
+		return err
+	}
+
+	w.Logger.InfoContext(
+		ctx,
+		"assess CNAME complete",
+		"domain",
+		job.Args.DomainUID,
+		"duration",
+		time.Since(start),
+	)
 	return nil
 }
 

--- a/internal/jobs/scan_jobs.go
+++ b/internal/jobs/scan_jobs.go
@@ -96,7 +96,12 @@ func (w *ScanCNAMEWorker) Work(ctx context.Context, job *river.Job[ScanCNAMEArgs
 	ctx = tracing.WithNewTraceID(ctx, false)
 	start := time.Now()
 
-	s := scanner.NewScanner(scanner.Config{Logger: &w.Logger, Store: w.Store, Resolver: w.Resolver})
+	s := scanner.NewScanner(scanner.Config{
+		Logger:   &w.Logger,
+		Store:    w.Store,
+		Resolver: w.Resolver,
+		Identity: job.Args.Identity(),
+	})
 	result := s.ScanCNAME(job.Args.DomainName)
 
 	w.Logger.InfoContext(
@@ -104,15 +109,11 @@ func (w *ScanCNAMEWorker) Work(ctx context.Context, job *river.Job[ScanCNAMEArgs
 		"cname scan complete",
 		"domain", job.Args.DomainName,
 		"duration", time.Since(start),
-		"result", result, // remove, debugging only pre-alpha
+		"cname_count", len(result.CNAME),
 	)
-	rc := river.ClientFromContext[pgx.Tx](ctx)
-	// todo: This isn't done inside a tx so we can't InsertTx easily.
-	_, err := rc.Insert(ctx, &AssessCNAMEDanglingArgs{DomainJobArgs: job.Args.DomainJobArgs}, nil)
-	if err != nil {
-		return err
-	}
-	return nil
+
+	return enqueueAssessment(ctx, w.PgxPool, &w.Logger, job.Args.DomainUID,
+		AssessCNAMEDanglingArgs{DomainJobArgs: job.Args.DomainJobArgs})
 }
 
 type ScanDNSSECArgs struct {

--- a/internal/observer/recorder.go
+++ b/internal/observer/recorder.go
@@ -49,6 +49,9 @@ const (
 	EntityCertificateFinding  = "certificate_finding"
 	EntityDNSSEC              = "dnssec"
 	EntityDNSSECFinding       = "dnssec_finding"
+
+	EntityCNAMEDanglingFinding    = "dangling_cname_finding"
+	EntityCNAMERedirectionFinding = "cname_redirection_finding"
 )
 
 // DomainIdentity is the stable identity stamped onto every observation. It is

--- a/internal/store/assessors.sql.go
+++ b/internal/store/assessors.sql.go
@@ -359,6 +359,52 @@ func (q *Queries) AssessGetCertificateFindingsByDomainUID(ctx context.Context, a
 	return items, nil
 }
 
+const assessGetCnameRedirectionFindingsByDomainUID = `-- name: AssessGetCnameRedirectionFindingsByDomainUID :many
+SELECT crf.id, crf.uid, crf.domain_id, crf.cname_record_id, crf.severity, crf.status, crf.issue_type, crf.chain_length, crf.details, crf.created_at, crf.updated_at
+FROM cname_redirection_findings crf
+         JOIN domains d ON crf.domain_id = d.id
+WHERE d.uid = $1
+  AND d.tenant_id = $2
+ORDER BY crf.severity ASC, crf.created_at DESC
+`
+
+type AssessGetCnameRedirectionFindingsByDomainUIDParams struct {
+	Uid      string      `json:"uid"`
+	TenantID pgtype.Int4 `json:"tenant_id"`
+}
+
+func (q *Queries) AssessGetCnameRedirectionFindingsByDomainUID(ctx context.Context, arg AssessGetCnameRedirectionFindingsByDomainUIDParams) ([]CnameRedirectionFindings, error) {
+	rows, err := q.db.Query(ctx, assessGetCnameRedirectionFindingsByDomainUID, arg.Uid, arg.TenantID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []CnameRedirectionFindings{}
+	for rows.Next() {
+		var i CnameRedirectionFindings
+		if err := rows.Scan(
+			&i.ID,
+			&i.Uid,
+			&i.DomainID,
+			&i.CnameRecordID,
+			&i.Severity,
+			&i.Status,
+			&i.IssueType,
+			&i.ChainLength,
+			&i.Details,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const assessGetDKIMFindings = `-- name: AssessGetDKIMFindings :many
 SELECT id, uid, domain_id, txt_record_id, severity, status, selector, issue_type, details, dkim_value, created_at, updated_at
 FROM dkim_findings
@@ -518,6 +564,52 @@ func (q *Queries) AssessGetDNSSECFindingsByDomainUID(ctx context.Context, arg As
 			&i.Severity,
 			&i.Status,
 			&i.IssueType,
+			&i.Details,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const assessGetDanglingCnameFindingsByDomainUID = `-- name: AssessGetDanglingCnameFindingsByDomainUID :many
+SELECT dcf.id, dcf.uid, dcf.domain_id, dcf.severity, dcf.status, dcf.target_domain, dcf.service_provider, dcf.takeover_possible, dcf.details, dcf.created_at, dcf.updated_at
+FROM dangling_cname_findings dcf
+         JOIN domains d ON dcf.domain_id = d.id
+WHERE d.uid = $1
+  AND d.tenant_id = $2
+ORDER BY dcf.severity ASC, dcf.created_at DESC
+`
+
+type AssessGetDanglingCnameFindingsByDomainUIDParams struct {
+	Uid      string      `json:"uid"`
+	TenantID pgtype.Int4 `json:"tenant_id"`
+}
+
+func (q *Queries) AssessGetDanglingCnameFindingsByDomainUID(ctx context.Context, arg AssessGetDanglingCnameFindingsByDomainUIDParams) ([]DanglingCnameFindings, error) {
+	rows, err := q.db.Query(ctx, assessGetDanglingCnameFindingsByDomainUID, arg.Uid, arg.TenantID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []DanglingCnameFindings{}
+	for rows.Next() {
+		var i DanglingCnameFindings
+		if err := rows.Scan(
+			&i.ID,
+			&i.Uid,
+			&i.DomainID,
+			&i.Severity,
+			&i.Status,
+			&i.TargetDomain,
+			&i.ServiceProvider,
+			&i.TakeoverPossible,
 			&i.Details,
 			&i.CreatedAt,
 			&i.UpdatedAt,
@@ -729,6 +821,12 @@ open_findings AS (
     UNION ALL
     SELECT domain_id, severity::text FROM dnssec_findings
         WHERE status = 'open' AND domain_id = ANY($1::int[])
+    UNION ALL
+    SELECT domain_id, severity::text FROM dangling_cname_findings
+        WHERE status = 'open' AND domain_id = ANY($1::int[])
+    UNION ALL
+    SELECT domain_id, severity::text FROM cname_redirection_findings
+        WHERE status = 'open' AND domain_id = ANY($1::int[])
 )
 SELECT
     ids.domain_id::int AS domain_id,
@@ -849,7 +947,27 @@ FROM (SELECT sf.uid                AS finding_uid,
       FROM dnssec_findings nf
                JOIN domains d ON nf.domain_id = d.id
       WHERE d.tenant_id = $1
-        AND ($2::bool OR nf.status = 'open')) f
+        AND ($2::bool OR nf.status = 'open')
+
+      UNION ALL
+
+      SELECT dcf.uid, d.uid, d.name, 'DANGLING'::text, dcf.severity, dcf.status,
+             CASE WHEN dcf.takeover_possible
+                  THEN 'subdomain_takeover' ELSE 'dangling_cname' END,
+             dcf.target_domain, dcf.details, NULL::text, dcf.created_at
+      FROM dangling_cname_findings dcf
+               JOIN domains d ON dcf.domain_id = d.id
+      WHERE d.tenant_id = $1
+        AND ($2::bool OR dcf.status = 'open')
+
+      UNION ALL
+
+      SELECT crf.uid, d.uid, d.name, 'CNAME'::text, crf.severity, crf.status,
+             crf.issue_type, NULL::text, crf.details, NULL::text, crf.created_at
+      FROM cname_redirection_findings crf
+               JOIN domains d ON crf.domain_id = d.id
+      WHERE d.tenant_id = $1
+        AND ($2::bool OR crf.status = 'open')) f
 ORDER BY f.domain_name ASC,
          CASE f.severity
              WHEN 'critical' THEN 1
@@ -917,6 +1035,92 @@ func (q *Queries) FindingsListByTenant(ctx context.Context, arg FindingsListByTe
 		return nil, err
 	}
 	return items, nil
+}
+
+const storeCnameRedirectionFinding = `-- name: StoreCnameRedirectionFinding :one
+INSERT INTO cname_redirection_findings (domain_id,
+                                        cname_record_id,
+                                        severity,
+                                        status,
+                                        issue_type,
+                                        chain_length,
+                                        details)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
+ON CONFLICT (domain_id, issue_type)
+    DO UPDATE SET cname_record_id = $2,
+                  severity        = $3,
+                  status          = $4,
+                  chain_length    = $6,
+                  details         = $7
+RETURNING (xmax = 0)::boolean AS inserted
+`
+
+type StoreCnameRedirectionFindingParams struct {
+	DomainID      pgtype.Int4     `json:"domain_id"`
+	CnameRecordID pgtype.Int4     `json:"cname_record_id"`
+	Severity      FindingSeverity `json:"severity"`
+	Status        FindingStatus   `json:"status"`
+	IssueType     string          `json:"issue_type"`
+	ChainLength   pgtype.Int4     `json:"chain_length"`
+	Details       pgtype.Text     `json:"details"`
+}
+
+func (q *Queries) StoreCnameRedirectionFinding(ctx context.Context, arg StoreCnameRedirectionFindingParams) (bool, error) {
+	row := q.db.QueryRow(ctx, storeCnameRedirectionFinding,
+		arg.DomainID,
+		arg.CnameRecordID,
+		arg.Severity,
+		arg.Status,
+		arg.IssueType,
+		arg.ChainLength,
+		arg.Details,
+	)
+	var inserted bool
+	err := row.Scan(&inserted)
+	return inserted, err
+}
+
+const storeDanglingCnameFinding = `-- name: StoreDanglingCnameFinding :one
+INSERT INTO dangling_cname_findings (domain_id,
+                                     severity,
+                                     status,
+                                     target_domain,
+                                     service_provider,
+                                     takeover_possible,
+                                     details)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
+ON CONFLICT (domain_id, target_domain)
+    DO UPDATE SET severity          = $2,
+                  status            = $3,
+                  service_provider  = $5,
+                  takeover_possible = $6,
+                  details           = $7
+RETURNING (xmax = 0)::boolean AS inserted
+`
+
+type StoreDanglingCnameFindingParams struct {
+	DomainID         pgtype.Int4     `json:"domain_id"`
+	Severity         FindingSeverity `json:"severity"`
+	Status           FindingStatus   `json:"status"`
+	TargetDomain     string          `json:"target_domain"`
+	ServiceProvider  pgtype.Text     `json:"service_provider"`
+	TakeoverPossible bool            `json:"takeover_possible"`
+	Details          pgtype.Text     `json:"details"`
+}
+
+func (q *Queries) StoreDanglingCnameFinding(ctx context.Context, arg StoreDanglingCnameFindingParams) (bool, error) {
+	row := q.db.QueryRow(ctx, storeDanglingCnameFinding,
+		arg.DomainID,
+		arg.Severity,
+		arg.Status,
+		arg.TargetDomain,
+		arg.ServiceProvider,
+		arg.TakeoverPossible,
+		arg.Details,
+	)
+	var inserted bool
+	err := row.Scan(&inserted)
+	return inserted, err
 }
 
 const storeZoneTransferFinding = `-- name: StoreZoneTransferFinding :one
@@ -998,6 +1202,10 @@ FROM (
         SELECT domain_id, severity::text FROM certificate_findings WHERE status = 'open'
         UNION ALL
         SELECT domain_id, severity::text FROM dnssec_findings WHERE status = 'open'
+        UNION ALL
+        SELECT domain_id, severity::text FROM dangling_cname_findings WHERE status = 'open'
+        UNION ALL
+        SELECT domain_id, severity::text FROM cname_redirection_findings WHERE status = 'open'
     ) f ON f.domain_id = d.id
     GROUP BY d.tenant_id, d.id
 ) agg

--- a/sql/queries/assessors.sql
+++ b/sql/queries/assessors.sql
@@ -63,6 +63,56 @@ WHERE d.uid = $1
   AND d.tenant_id = $2
 ORDER BY df.severity ASC, df.created_at DESC;
 
+-- name: StoreDanglingCnameFinding :one
+INSERT INTO dangling_cname_findings (domain_id,
+                                     severity,
+                                     status,
+                                     target_domain,
+                                     service_provider,
+                                     takeover_possible,
+                                     details)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
+ON CONFLICT (domain_id, target_domain)
+    DO UPDATE SET severity          = $2,
+                  status            = $3,
+                  service_provider  = $5,
+                  takeover_possible = $6,
+                  details           = $7
+RETURNING (xmax = 0)::boolean AS inserted;
+
+-- name: AssessGetDanglingCnameFindingsByDomainUID :many
+SELECT dcf.*
+FROM dangling_cname_findings dcf
+         JOIN domains d ON dcf.domain_id = d.id
+WHERE d.uid = $1
+  AND d.tenant_id = $2
+ORDER BY dcf.severity ASC, dcf.created_at DESC;
+
+-- name: StoreCnameRedirectionFinding :one
+INSERT INTO cname_redirection_findings (domain_id,
+                                        cname_record_id,
+                                        severity,
+                                        status,
+                                        issue_type,
+                                        chain_length,
+                                        details)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
+ON CONFLICT (domain_id, issue_type)
+    DO UPDATE SET cname_record_id = $2,
+                  severity        = $3,
+                  status          = $4,
+                  chain_length    = $6,
+                  details         = $7
+RETURNING (xmax = 0)::boolean AS inserted;
+
+-- name: AssessGetCnameRedirectionFindingsByDomainUID :many
+SELECT crf.*
+FROM cname_redirection_findings crf
+         JOIN domains d ON crf.domain_id = d.id
+WHERE d.uid = $1
+  AND d.tenant_id = $2
+ORDER BY crf.severity ASC, crf.created_at DESC;
+
 -- name: AssessCreateSPFFinding :one
 INSERT INTO spf_findings (domain_id,
                           txt_record_id,
@@ -219,6 +269,12 @@ open_findings AS (
     UNION ALL
     SELECT domain_id, severity::text FROM dnssec_findings
         WHERE status = 'open' AND domain_id = ANY(@domain_ids::int[])
+    UNION ALL
+    SELECT domain_id, severity::text FROM dangling_cname_findings
+        WHERE status = 'open' AND domain_id = ANY(@domain_ids::int[])
+    UNION ALL
+    SELECT domain_id, severity::text FROM cname_redirection_findings
+        WHERE status = 'open' AND domain_id = ANY(@domain_ids::int[])
 )
 SELECT
     ids.domain_id::int AS domain_id,
@@ -314,7 +370,27 @@ FROM (SELECT sf.uid                AS finding_uid,
       FROM dnssec_findings nf
                JOIN domains d ON nf.domain_id = d.id
       WHERE d.tenant_id = @tenant_id
-        AND (@include_compliant::bool OR nf.status = 'open')) f
+        AND (@include_compliant::bool OR nf.status = 'open')
+
+      UNION ALL
+
+      SELECT dcf.uid, d.uid, d.name, 'DANGLING'::text, dcf.severity, dcf.status,
+             CASE WHEN dcf.takeover_possible
+                  THEN 'subdomain_takeover' ELSE 'dangling_cname' END,
+             dcf.target_domain, dcf.details, NULL::text, dcf.created_at
+      FROM dangling_cname_findings dcf
+               JOIN domains d ON dcf.domain_id = d.id
+      WHERE d.tenant_id = @tenant_id
+        AND (@include_compliant::bool OR dcf.status = 'open')
+
+      UNION ALL
+
+      SELECT crf.uid, d.uid, d.name, 'CNAME'::text, crf.severity, crf.status,
+             crf.issue_type, NULL::text, crf.details, NULL::text, crf.created_at
+      FROM cname_redirection_findings crf
+               JOIN domains d ON crf.domain_id = d.id
+      WHERE d.tenant_id = @tenant_id
+        AND (@include_compliant::bool OR crf.status = 'open')) f
 ORDER BY f.domain_name ASC,
          CASE f.severity
              WHEN 'critical' THEN 1
@@ -358,6 +434,10 @@ FROM (
         SELECT domain_id, severity::text FROM certificate_findings WHERE status = 'open'
         UNION ALL
         SELECT domain_id, severity::text FROM dnssec_findings WHERE status = 'open'
+        UNION ALL
+        SELECT domain_id, severity::text FROM dangling_cname_findings WHERE status = 'open'
+        UNION ALL
+        SELECT domain_id, severity::text FROM cname_redirection_findings WHERE status = 'open'
     ) f ON f.domain_id = d.id
     GROUP BY d.tenant_id, d.id
 ) agg


### PR DESCRIPTION
## Summary

Implements the CNAME dangling / subdomain-takeover assessor (#30), replacing the hollow `AssessCNAMEDanglingWorker` stub that constructed an assessor, discarded it, and returned `nil`. Every scan previously "succeeded" with zero CNAME findings regardless of a domain's real state.

The assessor now reads the domain's persisted CNAME records, re-resolves each target live to detect non-resolving (NXDOMAIN) targets, fingerprints takeover-able providers, and actively probes resolving candidates over HTTP(S) to confirm or suppress findings under a conservative false-positive policy.

## What's included

- **Assessor** (`internal/assessor/assess_cname.go`): pure `classifyDangling` policy + orchestration over the domain's CNAME records.
  - Non-resolving target alone → `medium`, `takeover_possible=false`.
  - Takeover-able provider with a confirmed unclaimed page (or NXDOMAIN) → `high`, `takeover_possible=true`, `service_provider` set.
  - A live page on a takeover provider is suppressed (false-positive guard).
  - CNAME chain-hygiene findings: `points_to_ip`, `long_chain`, `cname_loop`.
- **Fingerprints** (`cname_fingerprints.go`): curated, high-confidence provider catalogue.
- **HTTP prober** (`prober.go`): injectable interface (real impl + test fake). Bounded by the `queue_assessor` concurrency cap, a per-job errgroup, and a per-request timeout; probing runs outside any DB transaction.
- **Persistence**: findings written to the existing `dangling_cname_findings` / `cname_redirection_findings` tables and surfaced through the tenant findings views (`FindingsListByTenant`, `DomainsListFindingsSummary`, `TenantFindingStatsAll`). Migration `00018` adds the `UNIQUE` constraints the upserts require.
- **Observations** emitted via the recorder (`dangling_cname_finding` / `cname_redirection_finding` entity types).
- **Worker wiring**: `AssessCNAMEDanglingWorker` now runs the assessor with the scan identity; `ScanCNAMEWorker` passes the identity and enqueues the assessment transactionally.

## Also fixes a pre-existing email-security tenancy bug

`assessDKIM` / `assessDMARC` looked up the domain with a hardcoded `tenant_id=1`, so email assessment failed with `get domain: N no rows` for any domain outside the default tenant, aborting the SPF/DKIM/DMARC errgroup. They now use the scan identity's tenant, matching the other assessors. Includes a regression test that assesses a domain under a non-default tenant.

## Notes

- Active probing is **not** feature-flagged (deliberate choice); it is bounded by the queue concurrency cap and per-request timeout rather than a flag.
- CNAME input is read from the existing `cname_records` (populated by the resolver) and re-resolved live, rather than introducing a separate scan-results table.
