### PR TITLE
Live domain updates via Datastar SSE over Postgres LISTEN/NOTIFY

### DIFF
--- a/internal/observer/notify_integration_test.go
+++ b/internal/observer/notify_integration_test.go
@@ -1,0 +1,164 @@
+package observer_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/danielmichaels/gecko/internal/observer"
+	"github.com/danielmichaels/gecko/internal/store"
+	"github.com/danielmichaels/gecko/internal/testhelpers"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+type notifyPayload struct {
+	TenantID   int32  `json:"tenant_id"`
+	DomainID   int32  `json:"domain_id"`
+	DomainUID  string `json:"domain_uid"`
+	DomainName string `json:"domain_name"`
+	ScanID     int64  `json:"scan_id"`
+	EntityType string `json:"entity_type"`
+	ChangeType string `json:"change_type"`
+}
+
+// TestRecorderNotifiesOnChange asserts that a real DNS-record change fires a
+// pg_notify on the domain_observations channel carrying the domain identity, so
+// the server process can fan the change out to browser SSE streams.
+func TestRecorderNotifiesOnChange(t *testing.T) {
+	testhelpers.ParallelDBTest(t)
+	ctx := context.Background()
+	pc, err := testhelpers.CreatePostgresContainer(ctx)
+	if err != nil {
+		t.Fatalf("failed to create postgres container: %v", err)
+	}
+	defer pc.Close(ctx)
+
+	const tenantID = int32(1)
+	d, err := pc.Queries.DomainsInsert(ctx, store.DomainsInsertParams{
+		TenantID:   pgtype.Int4{Int32: tenantID, Valid: true},
+		Name:       "notify.example.com",
+		DomainType: store.DomainTypeSubdomain,
+		Source:     store.DomainSourceUserSupplied,
+		Status:     store.DomainStatusActive,
+	})
+	if err != nil {
+		t.Fatalf("create domain: %v", err)
+	}
+	scan, err := pc.Queries.ScansCreate(ctx, store.ScansCreateParams{
+		TenantID:   tenantID,
+		DomainID:   pgtype.Int4{Int32: d.ID, Valid: true},
+		DomainUid:  d.Uid,
+		DomainName: d.Name,
+		Source:     store.DomainSourceUserSupplied,
+	})
+	if err != nil {
+		t.Fatalf("create scan: %v", err)
+	}
+	ident := observer.DomainIdentity{
+		TenantID:   tenantID,
+		DomainID:   d.ID,
+		DomainUID:  d.Uid,
+		DomainName: d.Name,
+		ScanID:     scan.ID,
+	}
+
+	listener, err := pc.Pool.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("acquire listener conn: %v", err)
+	}
+	defer listener.Release()
+	if _, err := listener.Exec(ctx, "LISTEN domain_observations"); err != nil {
+		t.Fatalf("LISTEN: %v", err)
+	}
+
+	tx, err := pc.Pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+	rec := observer.New(pc.Queries.WithTx(tx))
+	if err := rec.RecordA(ctx, ident, []string{"1.1.1.1"}, true); err != nil {
+		_ = tx.Rollback(ctx)
+		t.Fatalf("RecordA: %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	n, err := listener.Conn().WaitForNotification(waitCtx)
+	if err != nil {
+		t.Fatalf("expected a notification, got: %v", err)
+	}
+	var got notifyPayload
+	if err := json.Unmarshal([]byte(n.Payload), &got); err != nil {
+		t.Fatalf("notification payload not JSON: %q: %v", n.Payload, err)
+	}
+	if got.DomainUID != d.Uid || got.TenantID != tenantID {
+		t.Fatalf("notification identity = %+v, want tenant %d domain %s", got, tenantID, d.Uid)
+	}
+	if got.ScanID != scan.ID {
+		t.Errorf("notification scan_id = %d, want %d", got.ScanID, scan.ID)
+	}
+}
+
+// TestRecorderSuppressedFindingDoesNotNotify asserts that an unchanged
+// re-observation (which the recorder suppresses) fires no notification — the
+// notify must be gated on a real write, not merely the attempt.
+func TestRecorderSuppressedFindingDoesNotNotify(t *testing.T) {
+	testhelpers.ParallelDBTest(t)
+	ctx := context.Background()
+	pc, err := testhelpers.CreatePostgresContainer(ctx)
+	if err != nil {
+		t.Fatalf("failed to create postgres container: %v", err)
+	}
+	defer pc.Close(ctx)
+
+	const tenantID = int32(1)
+	d, err := pc.Queries.DomainsInsert(ctx, store.DomainsInsertParams{
+		TenantID:   pgtype.Int4{Int32: tenantID, Valid: true},
+		Name:       "suppress.example.com",
+		DomainType: store.DomainTypeSubdomain,
+		Source:     store.DomainSourceUserSupplied,
+		Status:     store.DomainStatusActive,
+	})
+	if err != nil {
+		t.Fatalf("create domain: %v", err)
+	}
+	ident := observer.DomainIdentity{
+		TenantID:   tenantID,
+		DomainID:   d.ID,
+		DomainUID:  d.Uid,
+		DomainName: d.Name,
+	}
+
+	payload := observer.PayloadJSON(map[string]any{"finding": "spf_missing"})
+	rec := observer.New(pc.Queries)
+	// First sighting writes (and notifies); we don't assert on it here.
+	if err := rec.RecordFindingChange(ctx, ident, observer.EntitySPFFinding, "spf", payload); err != nil {
+		t.Fatalf("first RecordFindingChange: %v", err)
+	}
+
+	listener, err := pc.Pool.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("acquire listener conn: %v", err)
+	}
+	defer listener.Release()
+	if _, err := listener.Exec(ctx, "LISTEN domain_observations"); err != nil {
+		t.Fatalf("LISTEN: %v", err)
+	}
+
+	// Identical payload -> suppressed -> must NOT notify.
+	if err := rec.RecordFindingChange(ctx, ident, observer.EntitySPFFinding, "spf", payload); err != nil {
+		t.Fatalf("second RecordFindingChange: %v", err)
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer cancel()
+	n, err := listener.Conn().WaitForNotification(waitCtx)
+	if err == nil {
+		t.Fatalf("expected no notification for suppressed write, got: %q", n.Payload)
+	}
+}

--- a/internal/observer/recorder.go
+++ b/internal/observer/recorder.go
@@ -52,6 +52,11 @@ const (
 
 	EntityCNAMEDanglingFinding    = "dangling_cname_finding"
 	EntityCNAMERedirectionFinding = "cname_redirection_finding"
+
+	// EntityDomain is used only on lifecycle NOTIFY signals (create/delete/status),
+	// never stored as an observation — a domain's existence is the projection
+	// itself. It lets the UI refresh on changes that write no observation row.
+	EntityDomain = "domain"
 )
 
 // DomainIdentity is the stable identity stamped onto every observation. It is
@@ -148,7 +153,26 @@ func (r *Recorder) sync(
 			return err
 		}
 	}
+	if change := summarizeChange(created, updated, deleted); change != "" {
+		r.notify(ctx, ident, entityType, change)
+	}
 	return nil
+}
+
+// summarizeChange picks one representative change_type for a sync's NOTIFY signal
+// (the signal only tells the UI "this domain changed" — it re-renders the row
+// regardless of which entity moved). Empty when nothing changed.
+func summarizeChange(created, updated, deleted []string) string {
+	switch {
+	case len(created) > 0:
+		return ChangeCreated
+	case len(updated) > 0:
+		return ChangeUpdated
+	case len(deleted) > 0:
+		return ChangeDeleted
+	default:
+		return ""
+	}
 }
 
 // RecordFindingChange appends one observation for a finding/attempt that the
@@ -182,12 +206,81 @@ func (r *Recorder) RecordFindingChange(
 		Payload:    payload,
 	})
 	if errors.Is(err, pgx.ErrNoRows) {
-		return nil // payload unchanged; suppressed
+		return nil // payload unchanged; suppressed — no real write, so no signal
 	}
 	if err != nil {
 		return fmt.Errorf("emit %s observation for %q: %w", entityType, entityKey, err)
 	}
+	r.notify(ctx, ident, entityType, ChangeUpdated)
 	return nil
+}
+
+// notify fires the LISTEN/NOTIFY signal for a domain change. It is best-effort:
+// a failed signal must never fail the observation write that already succeeded,
+// and a zero identity (unit tests without a scan) emits nothing. The payload is a
+// fixed-shape JSON object well under the 8 KB NOTIFY limit.
+func (r *Recorder) notify(
+	ctx context.Context,
+	ident DomainIdentity,
+	entityType, changeType string,
+) {
+	if !ident.Recordable() {
+		return
+	}
+	payload, err := json.Marshal(notifyPayload{
+		TenantID:   ident.TenantID,
+		DomainID:   ident.DomainID,
+		DomainUID:  ident.DomainUID,
+		DomainName: ident.DomainName,
+		ScanID:     ident.ScanID,
+		EntityType: entityType,
+		ChangeType: changeType,
+	})
+	if err != nil {
+		return
+	}
+	_ = r.q.NotifyDomainObservation(ctx, string(payload))
+}
+
+// NotifyDomainLifecycle fires a best-effort domain_observations NOTIFY for a
+// domain lifecycle change (create/delete/status) that writes no observation row
+// of its own, so live browser streams refresh. Pass the same store handle the
+// mutation ran on (transaction-scoped where applicable) so the signal commits
+// with it. A failed signal never surfaces — the mutation has already succeeded.
+func NotifyDomainLifecycle(
+	ctx context.Context,
+	q *store.Queries,
+	tenantID, domainID int32,
+	domainUID, domainName, changeType string,
+) {
+	if tenantID == 0 {
+		return
+	}
+	payload, err := json.Marshal(notifyPayload{
+		TenantID:   tenantID,
+		DomainID:   domainID,
+		DomainUID:  domainUID,
+		DomainName: domainName,
+		EntityType: EntityDomain,
+		ChangeType: changeType,
+	})
+	if err != nil {
+		return
+	}
+	_ = q.NotifyDomainObservation(ctx, string(payload))
+}
+
+// notifyPayload is the wire shape of a domain_observations NOTIFY. The server
+// process's listener decodes it and fans an ObservationEvent out to browser
+// streams on the tenant scope.
+type notifyPayload struct {
+	DomainUID  string `json:"domain_uid"`
+	DomainName string `json:"domain_name"`
+	EntityType string `json:"entity_type"`
+	ChangeType string `json:"change_type"`
+	ScanID     int64  `json:"scan_id"`
+	TenantID   int32  `json:"tenant_id"`
+	DomainID   int32  `json:"domain_id"`
 }
 
 // emit appends one row to the observation log, stamping the denormalized domain

--- a/internal/server/auth_integration_test.go
+++ b/internal/server/auth_integration_test.go
@@ -62,7 +62,14 @@ func newAuthAPI(
 		AuthProvider: provider,
 		Svc:          svc,
 		UI:           uiApp,
-		UIHandlers:   ui.NewHandlers(svc, uiApp, cookieCfg, slog.New(slog.DiscardHandler), true),
+		UIHandlers: ui.NewHandlers(
+			svc,
+			uiApp,
+			cookieCfg,
+			slog.New(slog.DiscardHandler),
+			true,
+			nil,
+		),
 	}
 	srv := httptest.NewServer(app.routes())
 	t.Cleanup(srv.Close)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -37,6 +37,7 @@ type Server struct {
 	AuthProvider auth.Provider
 	Svc          *service.Service
 	UI           *ui.App
+	Broker       *ui.SSEBroker
 	UIHandlers   *ui.Handlers
 }
 
@@ -68,6 +69,7 @@ func New(
 	}
 
 	uiApp := ui.New(svc.AuthService(), cookieCfg, csrfKey, l)
+	broker := ui.NewSSEBroker()
 	return &Server{
 		Conf:         c,
 		Log:          l,
@@ -77,7 +79,8 @@ func New(
 		AuthProvider: provider,
 		Svc:          svc,
 		UI:           uiApp,
-		UIHandlers:   ui.NewHandlers(svc, uiApp, cookieCfg, l, c.Auth.SignupEnabled),
+		Broker:       broker,
+		UIHandlers:   ui.NewHandlers(svc, uiApp, cookieCfg, l, c.Auth.SignupEnabled, broker),
 	}, nil
 }
 
@@ -137,6 +140,14 @@ func httpLogger(cfg *config.Conf) *httplog.Logger {
 }
 
 func (app *Server) Serve(ctx context.Context) error {
+	// Live-update fan-out: a dedicated standalone connection (cloned from the
+	// pool's config, NOT borrowed from the pool) holds the LISTEN so a lifelong
+	// subscription never reduces request-pool capacity. Reconnects re-dial.
+	connect := func(c context.Context) (*pgx.Conn, error) {
+		return pgx.ConnectConfig(c, app.PgxPool.Config().ConnConfig.Copy())
+	}
+	go ui.StartObservationListener(ctx, connect, app.Broker, app.Log)
+
 	srv := &http.Server{
 		Addr:         fmt.Sprintf(":%d", app.Conf.Server.APIPort),
 		Handler:      app.routes(),

--- a/internal/server/sse_deadline_test.go
+++ b/internal/server/sse_deadline_test.go
@@ -1,0 +1,53 @@
+package server
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5/middleware"
+)
+
+// deadlineBase is a ResponseWriter that records whether the per-connection
+// deadline setters were reached — i.e. whether http.ResponseController could
+// walk the wrapper chain all the way down to the real connection.
+type deadlineBase struct {
+	emptyResponseWriter
+	wroteDeadline bool
+	readDeadline  bool
+}
+
+func (d *deadlineBase) SetWriteDeadline(time.Time) error { d.wroteDeadline = true; return nil }
+func (d *deadlineBase) SetReadDeadline(time.Time) error  { d.readDeadline = true; return nil }
+func (d *deadlineBase) Flush()                           {}
+
+// TestSSEDeadlineClearsThroughWrappers proves http.ResponseController can clear
+// the read/write deadlines through the exact wrapper nesting an SSE handler sees
+// in production: sseStatusRecorder -> chi WrapResponseWriter -> base. If any
+// wrapper lacked Unwrap, the deadline clear would silently no-op and the server
+// timeout would tear the long-lived stream down on a cycle.
+func TestSSEDeadlineClearsThroughWrappers(t *testing.T) {
+	base := &deadlineBase{}
+	chiWrapped := middleware.NewWrapResponseWriter(base, 1)
+	w := &sseStatusRecorder{ResponseWriter: chiWrapped}
+
+	rc := http.NewResponseController(w)
+	if err := rc.SetWriteDeadline(time.Time{}); err != nil {
+		t.Fatalf("SetWriteDeadline through wrappers: %v", err)
+	}
+	if err := rc.SetReadDeadline(time.Time{}); err != nil {
+		t.Fatalf("SetReadDeadline through wrappers: %v", err)
+	}
+	if !base.wroteDeadline {
+		t.Error("write deadline did not reach the base connection (broken Unwrap chain)")
+	}
+	if !base.readDeadline {
+		t.Error("read deadline did not reach the base connection (broken Unwrap chain)")
+	}
+}
+
+type emptyResponseWriter struct{}
+
+func (emptyResponseWriter) Header() http.Header         { return http.Header{} }
+func (emptyResponseWriter) Write(b []byte) (int, error) { return len(b), nil }
+func (emptyResponseWriter) WriteHeader(int)             {}

--- a/internal/service/domains.go
+++ b/internal/service/domains.go
@@ -9,6 +9,7 @@ import (
 	"github.com/danielmichaels/gecko/internal/dnsrecords"
 	"github.com/danielmichaels/gecko/internal/dto"
 	"github.com/danielmichaels/gecko/internal/jobs"
+	"github.com/danielmichaels/gecko/internal/observer"
 	"github.com/danielmichaels/gecko/internal/store"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -277,6 +278,12 @@ func (s *DomainsService) Create(
 		return store.Domains{}, fmt.Errorf("schedule scan: %w", err)
 	}
 
+	// Signal live streams so the new domain appears on other open sessions
+	// immediately, not only once its first scan observation lands.
+	observer.NotifyDomainLifecycle(
+		ctx, st, p.TenantID, domain.ID, domain.Uid, domain.Name, observer.ChangeCreated,
+	)
+
 	if err := tx.Commit(ctx); err != nil {
 		return store.Domains{}, fmt.Errorf("commit: %w", err)
 	}
@@ -361,6 +368,12 @@ func (s *DomainsService) Update(
 		return store.Domains{}, fmt.Errorf("schedule scan: %w", err)
 	}
 
+	// Signal live streams: a status change is list-visible but writes no
+	// observation, and an inactive domain is never rescanned to produce one.
+	observer.NotifyDomainLifecycle(
+		ctx, st, p.TenantID, domain.ID, domain.Uid, domain.Name, observer.ChangeUpdated,
+	)
+
 	if err := tx.Commit(ctx); err != nil {
 		return store.Domains{}, fmt.Errorf("commit: %w", err)
 	}
@@ -388,7 +401,7 @@ func (s *DomainsService) Delete(
 	if err := ownerOrManager(p); err != nil {
 		return err
 	}
-	_, err := s.DB.DomainsDeleteByID(ctx, store.DomainsDeleteByIDParams{
+	deleted, err := s.DB.DomainsDeleteByID(ctx, store.DomainsDeleteByIDParams{
 		Uid:      uid,
 		TenantID: pgtype.Int4{Int32: p.TenantID, Valid: true},
 	})
@@ -398,6 +411,13 @@ func (s *DomainsService) Delete(
 		}
 		return fmt.Errorf("delete domain: %w", err)
 	}
+
+	// A delete writes no observation, so without an explicit signal live browser
+	// streams would not see the row (and any cascaded children) disappear until a
+	// reload. One tenant-scoped nudge refreshes the whole list.
+	observer.NotifyDomainLifecycle(
+		ctx, s.DB, p.TenantID, deleted.ID, deleted.Uid, deleted.Name, observer.ChangeDeleted,
+	)
 
 	// The delete cascaded away this domain's records/findings, so the tenant's
 	// cached counts (possibly now zero) are stale. Enqueue an immediate per-tenant

--- a/internal/service/notify_test.go
+++ b/internal/service/notify_test.go
@@ -1,0 +1,144 @@
+package service_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/danielmichaels/gecko/internal/service"
+	"github.com/danielmichaels/gecko/internal/testhelpers"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type uiNotification struct {
+	TenantID   int32  `json:"tenant_id"`
+	DomainUID  string `json:"domain_uid"`
+	EntityType string `json:"entity_type"`
+	ChangeType string `json:"change_type"`
+}
+
+// awaitDomainNotify LISTENs on domain_observations, runs mutate, and returns the
+// decoded notification (failing if none arrives).
+func awaitDomainNotify(
+	t *testing.T,
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	mutate func(),
+) uiNotification {
+	t.Helper()
+	listener, err := pool.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("acquire listener conn: %v", err)
+	}
+	defer listener.Release()
+	if _, err := listener.Exec(ctx, "LISTEN domain_observations"); err != nil {
+		t.Fatalf("LISTEN: %v", err)
+	}
+
+	mutate()
+
+	waitCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	n, err := listener.Conn().WaitForNotification(waitCtx)
+	if err != nil {
+		t.Fatalf("expected a notification, got: %v", err)
+	}
+	var got uiNotification
+	if err := json.Unmarshal([]byte(n.Payload), &got); err != nil {
+		t.Fatalf("payload not JSON: %q: %v", n.Payload, err)
+	}
+	return got
+}
+
+// TestDomainsService_Delete_NotifiesUI: a delete writes no observation of its
+// own, so without this signal the live list stays stale until a manual reload.
+func TestDomainsService_Delete_NotifiesUI(t *testing.T) {
+	testhelpers.ParallelDBTest(t)
+	ctx := context.Background()
+	pc, err := testhelpers.CreatePostgresContainer(ctx)
+	if err != nil {
+		t.Fatalf("create container: %v", err)
+	}
+	defer pc.Close(ctx)
+
+	svc := newTestService(pc, &fakeScheduler{})
+	ds := svc.DomainsService()
+	tenant := createTenant(t, ctx, pc, "a@notify-del.com")
+	d := seedDomain(t, ctx, pc, tenant, "del.example.com")
+
+	got := awaitDomainNotify(t, ctx, pc.Pool, func() {
+		if err := ds.Delete(ctx, ownerPrincipal(tenant), d.Uid); err != nil {
+			t.Fatalf("Delete: %v", err)
+		}
+	})
+	if got.TenantID != tenant || got.DomainUID != d.Uid {
+		t.Fatalf("notification = %+v, want tenant %d domain %s", got, tenant, d.Uid)
+	}
+	if got.EntityType != "domain" || got.ChangeType != "deleted" {
+		t.Errorf("notification = %+v, want entity 'domain' change 'deleted'", got)
+	}
+}
+
+// TestDomainsService_Create_NotifiesUI: a newly added domain should appear on
+// other open sessions immediately, not only once its first scan observation
+// lands.
+func TestDomainsService_Create_NotifiesUI(t *testing.T) {
+	testhelpers.ParallelDBTest(t)
+	ctx := context.Background()
+	pc, err := testhelpers.CreatePostgresContainer(ctx)
+	if err != nil {
+		t.Fatalf("create container: %v", err)
+	}
+	defer pc.Close(ctx)
+
+	svc := newTestService(pc, &fakeScheduler{})
+	ds := svc.DomainsService()
+	tenant := createTenant(t, ctx, pc, "a@notify-create.com")
+
+	got := awaitDomainNotify(t, ctx, pc.Pool, func() {
+		if _, err := ds.Create(ctx, ownerPrincipal(tenant), service.DomainsCreateParams{
+			Domain: "new.example.com",
+		}); err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+	})
+	if got.TenantID != tenant {
+		t.Fatalf("notification = %+v, want tenant %d", got, tenant)
+	}
+	if got.EntityType != "domain" || got.ChangeType != "created" {
+		t.Errorf("notification = %+v, want entity 'domain' change 'created'", got)
+	}
+}
+
+// TestDomainsService_Update_NotifiesUI: a status change (e.g. active->inactive)
+// is list-visible but writes no observation — and an inactive domain is never
+// rescanned, so the signal is the only way the live list reflects it.
+func TestDomainsService_Update_NotifiesUI(t *testing.T) {
+	testhelpers.ParallelDBTest(t)
+	ctx := context.Background()
+	pc, err := testhelpers.CreatePostgresContainer(ctx)
+	if err != nil {
+		t.Fatalf("create container: %v", err)
+	}
+	defer pc.Close(ctx)
+
+	svc := newTestService(pc, &fakeScheduler{})
+	ds := svc.DomainsService()
+	tenant := createTenant(t, ctx, pc, "a@notify-update.com")
+	d := seedDomain(t, ctx, pc, tenant, "upd.example.com")
+
+	got := awaitDomainNotify(t, ctx, pc.Pool, func() {
+		if _, err := ds.Update(ctx, ownerPrincipal(tenant), d.Uid, service.DomainsUpdateParams{
+			Status: "inactive",
+		}); err != nil {
+			t.Fatalf("Update: %v", err)
+		}
+	})
+	if got.TenantID != tenant || got.DomainUID != d.Uid {
+		t.Fatalf("notification = %+v, want tenant %d domain %s", got, tenant, d.Uid)
+	}
+	if got.EntityType != "domain" || got.ChangeType != "updated" {
+		t.Errorf("notification = %+v, want entity 'domain' change 'updated'", got)
+	}
+}

--- a/internal/store/observations.sql.go
+++ b/internal/store/observations.sql.go
@@ -23,6 +23,21 @@ func (q *Queries) AcquireDomainScanLock(ctx context.Context, dollar_1 int64) err
 	return err
 }
 
+const notifyDomainObservation = `-- name: NotifyDomainObservation :exec
+SELECT pg_notify('domain_observations', $1::text)
+`
+
+// Fire a LISTEN/NOTIFY signal that an observation was written for a domain. The
+// server process LISTENs on 'domain_observations' and fans the change out to
+// browser SSE streams. Called on the observation transaction's connection, so
+// the signal is delivered on COMMIT and dropped on ROLLBACK — subscribers never
+// observe uncommitted state. Delivery is best-effort: a listener that is down
+// when this fires misses the event (the DB stays source of truth).
+func (q *Queries) NotifyDomainObservation(ctx context.Context, payload string) error {
+	_, err := q.db.Exec(ctx, notifyDomainObservation, payload)
+	return err
+}
+
 const observationsCreate = `-- name: ObservationsCreate :one
 INSERT INTO domain_observations (tenant_id, domain_id, domain_uid, domain_name, scan_id, entity_type, entity_key,
                                  change_type, payload)

--- a/internal/ui/domain_handlers.go
+++ b/internal/ui/domain_handlers.go
@@ -463,8 +463,19 @@ func (h *Handlers) handleRecordsFragment(w http.ResponseWriter, r *http.Request)
 
 	uid := chi.URLParam(r, "uid")
 	sse := datastar.NewSSE(w, r)
+	h.patchRecordsContent(r.Context(), sse, p, uid)
+}
 
-	result, err := h.svc.RecordsService().List(r.Context(), p, uid, nil)
+// patchRecordsContent renders the DNS records panel into #records-content. It is
+// shared by the one-shot lazy-load endpoint and the detail live stream so a
+// streamed refresh is byte-identical to a manual load.
+func (h *Handlers) patchRecordsContent(
+	ctx context.Context,
+	sse *datastar.ServerSentEventGenerator,
+	p *auth.Principal,
+	uid string,
+) {
+	result, err := h.svc.RecordsService().List(ctx, p, uid, nil)
 	if err != nil {
 		retryURL := fmt.Sprintf("/app/domains/%s/records", uid)
 		msg := "failed to load records"
@@ -511,8 +522,18 @@ func (h *Handlers) handleTimelineFragment(w http.ResponseWriter, r *http.Request
 
 	uid := chi.URLParam(r, "uid")
 	sse := datastar.NewSSE(w, r)
+	h.patchTimelineContent(r.Context(), sse, p, uid)
+}
 
-	result, err := h.svc.RecordsService().Timeline(r.Context(), p, uid)
+// patchTimelineContent renders the side-panel change timeline into
+// #timeline-content. Shared by the lazy-load endpoint and the detail stream.
+func (h *Handlers) patchTimelineContent(
+	ctx context.Context,
+	sse *datastar.ServerSentEventGenerator,
+	p *auth.Principal,
+	uid string,
+) {
+	result, err := h.svc.RecordsService().Timeline(ctx, p, uid)
 	if err != nil {
 		retryURL := fmt.Sprintf("/app/domains/%s/timeline", uid)
 		msg := "failed to load timeline"
@@ -547,8 +568,20 @@ func (h *Handlers) handleTimelineFullFragment(w http.ResponseWriter, r *http.Req
 
 	uid := chi.URLParam(r, "uid")
 	sse := datastar.NewSSE(w, r)
+	highlightScan := strings.TrimSpace(r.URL.Query().Get("scan"))
+	h.patchTimelineFullContent(r.Context(), sse, p, uid, highlightScan)
+}
 
-	result, err := h.svc.RecordsService().Timeline(r.Context(), p, uid)
+// patchTimelineFullContent renders the full-width Timeline tab into
+// #timeline-full-content. Shared by the lazy-load endpoint and the detail stream
+// (which passes no scan highlight).
+func (h *Handlers) patchTimelineFullContent(
+	ctx context.Context,
+	sse *datastar.ServerSentEventGenerator,
+	p *auth.Principal,
+	uid, highlightScan string,
+) {
+	result, err := h.svc.RecordsService().Timeline(ctx, p, uid)
 	if err != nil {
 		msg := "failed to load timeline"
 		if errors.Is(err, service.ErrNotFound) {
@@ -565,7 +598,6 @@ func (h *Handlers) handleTimelineFullFragment(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	highlightScan := strings.TrimSpace(r.URL.Query().Get("scan"))
 	_ = sse.PatchElementTempl(
 		templates.TimelineFull(timelineFullView(result.Scans, highlightScan)),
 		datastar.WithSelectorID("timeline-full-content"),
@@ -583,8 +615,18 @@ func (h *Handlers) handleFindingsFragment(w http.ResponseWriter, r *http.Request
 
 	uid := chi.URLParam(r, "uid")
 	sse := datastar.NewSSE(w, r)
+	h.patchFindingsContent(r.Context(), sse, p, uid)
+}
 
-	result, err := h.svc.FindingsService().ListByDomain(r.Context(), p, uid)
+// patchFindingsContent renders the Findings tab into #findings-content. Shared by
+// the lazy-load endpoint and the detail stream.
+func (h *Handlers) patchFindingsContent(
+	ctx context.Context,
+	sse *datastar.ServerSentEventGenerator,
+	p *auth.Principal,
+	uid string,
+) {
+	result, err := h.svc.FindingsService().ListByDomain(ctx, p, uid)
 	if err != nil {
 		msg := "failed to load findings"
 		if errors.Is(err, service.ErrNotFound) {

--- a/internal/ui/handlers.go
+++ b/internal/ui/handlers.go
@@ -23,6 +23,7 @@ type Handlers struct {
 	svc           *service.Service
 	app           *App
 	log           *slog.Logger
+	broker        *SSEBroker
 	cookieCfg     CookieConfig
 	signupEnabled bool
 }
@@ -37,9 +38,13 @@ func NewHandlers(
 	cookieCfg CookieConfig,
 	log *slog.Logger,
 	signupEnabled bool,
+	broker *SSEBroker,
 ) *Handlers {
 	if log == nil {
 		log = slog.Default()
+	}
+	if broker == nil {
+		broker = NewSSEBroker()
 	}
 	return &Handlers{
 		svc:           svc,
@@ -47,8 +52,13 @@ func NewHandlers(
 		cookieCfg:     cookieCfg,
 		log:           log,
 		signupEnabled: signupEnabled,
+		broker:        broker,
 	}
 }
+
+// Broker returns the SSE broker the live-update streams subscribe to. The server
+// process feeds it from the Postgres LISTEN/NOTIFY listener.
+func (h *Handlers) Broker() *SSEBroker { return h.broker }
 
 // Routes returns a chi router for all browser-facing routes.
 // The router is intended to be mounted at /app by the server, so paths here do
@@ -103,9 +113,11 @@ func (h *Handlers) Routes() http.Handler {
 		r.Post("/settings/password", h.handlePasswordChange)
 
 		r.Get("/domains", h.handleDomainsGet)
+		r.Get("/domains/stream", h.handleDomainsStream)
 		r.Post("/domains", h.handleDomainCreate)
 		r.Post("/domains/rescan", h.handleDomainsRescanAll)
 		r.Get("/domains/{uid}", h.handleDomainDetail)
+		r.Get("/domains/{uid}/stream", h.handleDomainDetailStream)
 		r.Delete("/domains/{uid}", h.handleDomainDelete)
 		r.Post("/domains/{uid}/rescan", h.handleDomainRescan)
 		r.Get("/domains/{uid}/records", h.handleRecordsFragment)

--- a/internal/ui/handlers_test.go
+++ b/internal/ui/handlers_test.go
@@ -98,7 +98,7 @@ func newUIHarnessWithSignup(
 	}
 
 	app := ui.New(svc.AuthService(), cookieCfg, csrfKey, nil)
-	h := ui.NewHandlers(svc, app, cookieCfg, nil, signupEnabled)
+	h := ui.NewHandlers(svc, app, cookieCfg, nil, signupEnabled, nil)
 
 	root := chi.NewRouter()
 	root.Mount("/app", h.Routes())

--- a/internal/ui/listener.go
+++ b/internal/ui/listener.go
@@ -1,0 +1,110 @@
+package ui
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+const observationChannel = "domain_observations"
+
+// ObservationConnector opens a fresh, dedicated connection for the listener. It
+// must NOT hand back a connection borrowed from the request pool — a lifelong
+// LISTEN would permanently reduce that pool's capacity. Returning a standalone
+// pgx.Conn also makes reconnecting after a drop a simple "call it again".
+type ObservationConnector func(context.Context) (*pgx.Conn, error)
+
+// observationNotification is the wire shape emitted by the recorder's pg_notify.
+// It mirrors observer's notify payload; kept local so the ui package does not
+// import observer.
+type observationNotification struct {
+	DomainUID  string `json:"domain_uid"`
+	DomainName string `json:"domain_name"`
+	EntityType string `json:"entity_type"`
+	ChangeType string `json:"change_type"`
+	ScanID     int64  `json:"scan_id"`
+	TenantID   int32  `json:"tenant_id"`
+}
+
+// StartObservationListener LISTENs on the domain_observations channel and
+// republishes every notification to the broker on the originating tenant's
+// scope. It blocks until ctx is cancelled, reconnecting with capped backoff on
+// any connection loss. Run it in a goroutine from the server process. Delivery
+// is best-effort: notifications fired while the listener is reconnecting are
+// missed (the DB stays the source of truth).
+func StartObservationListener(
+	ctx context.Context,
+	connect ObservationConnector,
+	broker *SSEBroker,
+	log *slog.Logger,
+) {
+	if log == nil {
+		log = slog.Default()
+	}
+	const minBackoff, maxBackoff = time.Second, 30 * time.Second
+	backoff := minBackoff
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		err := listenOnce(ctx, connect, broker, log)
+		if ctx.Err() != nil {
+			return
+		}
+		log.Warn(
+			"observation listener disconnected; reconnecting",
+			"error",
+			err,
+			"backoff",
+			backoff,
+		)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		if backoff *= 2; backoff > maxBackoff {
+			backoff = maxBackoff
+		}
+	}
+}
+
+// listenOnce opens a connection, LISTENs, and pumps notifications into the broker
+// until the connection or context fails. It returns the error that ended the
+// loop so the caller can decide whether to reconnect.
+func listenOnce(
+	ctx context.Context,
+	connect ObservationConnector,
+	broker *SSEBroker,
+	log *slog.Logger,
+) error {
+	conn, err := connect(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Close(context.Background())
+
+	if _, err := conn.Exec(ctx, "LISTEN "+observationChannel); err != nil {
+		return err
+	}
+	log.Info("observation listener connected", "channel", observationChannel)
+
+	for {
+		n, err := conn.WaitForNotification(ctx)
+		if err != nil {
+			return err
+		}
+		var note observationNotification
+		if err := json.Unmarshal([]byte(n.Payload), &note); err != nil {
+			log.Warn("observation listener: bad payload", "payload", n.Payload, "error", err)
+			continue
+		}
+		// observationNotification and ObservationEvent share the same fields (the
+		// former only adds snake_case json tags for decoding the payload), so a
+		// direct conversion avoids a field-by-field copy.
+		broker.Publish(observationScope(note.TenantID), ObservationEvent(note))
+	}
+}

--- a/internal/ui/listener_test.go
+++ b/internal/ui/listener_test.go
@@ -1,0 +1,60 @@
+package ui_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/danielmichaels/gecko/internal/testhelpers"
+	"github.com/danielmichaels/gecko/internal/ui"
+	"github.com/jackc/pgx/v5"
+)
+
+// TestObservationListenerRepublishesToBroker asserts the listener turns a raw
+// Postgres NOTIFY on domain_observations into an ObservationEvent fanned out to
+// broker subscribers on the matching tenant scope.
+func TestObservationListenerRepublishesToBroker(t *testing.T) {
+	testhelpers.ParallelDBTest(t)
+	ctx := context.Background()
+	pc, err := testhelpers.CreatePostgresContainer(ctx)
+	if err != nil {
+		t.Fatalf("failed to create postgres container: %v", err)
+	}
+	defer pc.Close(ctx)
+
+	broker := ui.NewSSEBroker()
+	_, events := broker.Subscribe("tenant:7")
+
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	connect := func(c context.Context) (*pgx.Conn, error) {
+		return pgx.Connect(c, pc.ConnectionString)
+	}
+	go ui.StartObservationListener(runCtx, connect, broker, nil)
+
+	// LISTEN/NOTIFY only reaches sessions already listening, and the listener
+	// LISTENs asynchronously. Fire repeatedly until the event arrives or we give
+	// up, rather than racing a one-shot notify against listener startup.
+	payload := `{"tenant_id":7,"domain_id":3,"domain_uid":"dom_live","domain_name":"live.example.com","scan_id":9,"entity_type":"a_record","change_type":"created"}`
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+	deadline := time.After(5 * time.Second)
+	for {
+		if _, err := pc.Pool.Exec(ctx, "SELECT pg_notify('domain_observations', $1)", payload); err != nil {
+			t.Fatalf("pg_notify: %v", err)
+		}
+		select {
+		case evt := <-events:
+			if evt.TenantID != 7 || evt.DomainUID != "dom_live" {
+				t.Fatalf("event = %+v, want tenant 7 domain dom_live", evt)
+			}
+			if evt.ScanID != 9 || evt.EntityType != "a_record" {
+				t.Errorf("event = %+v, want scan 9 entity a_record", evt)
+			}
+			return
+		case <-ticker.C:
+		case <-deadline:
+			t.Fatal("listener never republished the notification to the broker")
+		}
+	}
+}

--- a/internal/ui/sse.go
+++ b/internal/ui/sse.go
@@ -1,0 +1,94 @@
+package ui
+
+import (
+	"strconv"
+	"sync"
+	"sync/atomic"
+)
+
+// observationScope is the broker scope a tenant's browser streams subscribe to.
+// Events are routed by tenant; per-domain filtering happens in the stream
+// handler (the detail page subscribes to the same tenant scope and ignores
+// events for other domains).
+func observationScope(tenantID int32) string {
+	return "tenant:" + strconv.Itoa(int(tenantID))
+}
+
+// subscriberBuffer bounds each subscriber's channel. A browser that falls behind
+// has events dropped rather than blocking the publisher — the DB stays the
+// source of truth, and a page reload reconciles any missed update.
+const subscriberBuffer = 32
+
+// ObservationEvent is the identity of a single domain change, fanned out from the
+// Postgres LISTEN/NOTIFY listener to every browser stream on the tenant scope.
+// It carries identity only (no rendered HTML): the row HTML embeds a per-session
+// CSRF token and role-gated controls, so each stream handler renders its own.
+type ObservationEvent struct {
+	DomainUID  string
+	DomainName string
+	EntityType string
+	ChangeType string
+	ScanID     int64
+	TenantID   int32
+}
+
+// SSEBroker is a scoped pub/sub hub fanning ObservationEvents out to all browser
+// streams subscribed to a scope. Publish is non-blocking: a full subscriber
+// buffer drops the event.
+type SSEBroker struct {
+	subscribers map[string]map[string]chan ObservationEvent
+	nextID      atomic.Uint64
+	mu          sync.RWMutex
+}
+
+// NewSSEBroker returns an empty broker ready for subscribers.
+func NewSSEBroker() *SSEBroker {
+	return &SSEBroker{subscribers: make(map[string]map[string]chan ObservationEvent)}
+}
+
+// Subscribe registers a new subscriber on scope and returns its id plus the
+// channel events arrive on. Unsubscribe with the returned id to stop delivery
+// and close the channel.
+func (b *SSEBroker) Subscribe(scope string) (string, <-chan ObservationEvent) {
+	id := strconv.FormatUint(b.nextID.Add(1), 10)
+	ch := make(chan ObservationEvent, subscriberBuffer)
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.subscribers[scope] == nil {
+		b.subscribers[scope] = make(map[string]chan ObservationEvent)
+	}
+	b.subscribers[scope][id] = ch
+	return id, ch
+}
+
+// Unsubscribe removes the subscriber and closes its channel. It is a no-op for an
+// unknown scope/id.
+func (b *SSEBroker) Unsubscribe(scope, id string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	subs := b.subscribers[scope]
+	if subs == nil {
+		return
+	}
+	if ch, ok := subs[id]; ok {
+		close(ch)
+		delete(subs, id)
+	}
+	if len(subs) == 0 {
+		delete(b.subscribers, scope)
+	}
+}
+
+// Publish fans evt out to every subscriber on scope. Delivery is non-blocking: a
+// subscriber whose buffer is full silently drops the event.
+func (b *SSEBroker) Publish(scope string, evt ObservationEvent) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	for _, ch := range b.subscribers[scope] {
+		select {
+		case ch <- evt:
+		default:
+		}
+	}
+}

--- a/internal/ui/sse_test.go
+++ b/internal/ui/sse_test.go
@@ -1,0 +1,107 @@
+package ui_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/danielmichaels/gecko/internal/ui"
+)
+
+func recv(t *testing.T, ch <-chan ui.ObservationEvent) (ui.ObservationEvent, bool) {
+	t.Helper()
+	select {
+	case evt, ok := <-ch:
+		return evt, ok
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for event")
+		return ui.ObservationEvent{}, false
+	}
+}
+
+func TestSSEBrokerSubscribeReceivesPublish(t *testing.T) {
+	t.Parallel()
+	b := ui.NewSSEBroker()
+	_, ch := b.Subscribe("tenant:1")
+
+	want := ui.ObservationEvent{TenantID: 1, DomainUID: "dom_abc", ChangeType: "created"}
+	b.Publish("tenant:1", want)
+
+	got, ok := recv(t, ch)
+	if !ok {
+		t.Fatal("channel closed unexpectedly")
+	}
+	if got != want {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestSSEBrokerScopesAreIsolated(t *testing.T) {
+	t.Parallel()
+	b := ui.NewSSEBroker()
+	_, ch := b.Subscribe("tenant:1")
+
+	b.Publish("tenant:2", ui.ObservationEvent{TenantID: 2})
+
+	select {
+	case evt := <-ch:
+		t.Fatalf("received cross-scope event: %+v", evt)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestSSEBrokerFanOutToAllSubscribers(t *testing.T) {
+	t.Parallel()
+	b := ui.NewSSEBroker()
+	_, ch1 := b.Subscribe("tenant:1")
+	_, ch2 := b.Subscribe("tenant:1")
+
+	want := ui.ObservationEvent{TenantID: 1, DomainUID: "dom_xyz"}
+	b.Publish("tenant:1", want)
+
+	for _, ch := range []<-chan ui.ObservationEvent{ch1, ch2} {
+		got, ok := recv(t, ch)
+		if !ok || got != want {
+			t.Fatalf("subscriber missed event: got %+v ok=%v", got, ok)
+		}
+	}
+}
+
+func TestSSEBrokerUnsubscribeStopsDelivery(t *testing.T) {
+	t.Parallel()
+	b := ui.NewSSEBroker()
+	id, ch := b.Subscribe("tenant:1")
+	b.Unsubscribe("tenant:1", id)
+
+	b.Publish("tenant:1", ui.ObservationEvent{TenantID: 1})
+
+	if _, ok := <-ch; ok {
+		t.Fatal("expected channel closed after unsubscribe")
+	}
+}
+
+func TestSSEBrokerPublishNoSubscribersIsNoop(t *testing.T) {
+	t.Parallel()
+	b := ui.NewSSEBroker()
+	// Must not panic or block.
+	b.Publish("tenant:999", ui.ObservationEvent{TenantID: 999})
+}
+
+func TestSSEBrokerFullBufferDropsWithoutBlocking(t *testing.T) {
+	t.Parallel()
+	b := ui.NewSSEBroker()
+	b.Subscribe("tenant:1") // never drained
+
+	done := make(chan struct{})
+	go func() {
+		for range 1000 {
+			b.Publish("tenant:1", ui.ObservationEvent{TenantID: 1})
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Publish blocked on a full subscriber buffer")
+	}
+}

--- a/internal/ui/stream.go
+++ b/internal/ui/stream.go
@@ -1,0 +1,182 @@
+package ui
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/danielmichaels/gecko/internal/service"
+	"github.com/danielmichaels/gecko/internal/ui/templates"
+	"github.com/go-chi/chi/v5"
+	datastar "github.com/starfederation/datastar-go/datastar"
+)
+
+// keepAliveInterval pings idle SSE streams so intermediaries (proxies, load
+// balancers) do not reap a long-lived connection that is merely quiet between
+// scans. It is distinct from clearing the server WriteTimeout, which stops Go
+// itself from closing the connection.
+const keepAliveInterval = 30 * time.Second
+
+// coalesceInterval bounds how often a stream reacts to a burst of observations.
+// An enumeration scan can write hundreds of observations in seconds; collapsing
+// them into one refresh per interval keeps the UI sub-second-live without a
+// flood of patches. It is the deliberate (evidence-driven) replacement for
+// per-observation patching, which clashed with the grouped layout and overran
+// the client.
+const coalesceInterval = 750 * time.Millisecond
+
+// coalescer collapses a burst of events into a single pending refresh: many
+// mark() calls between ticks yield exactly one take()==true.
+type coalescer struct{ pending bool }
+
+func (c *coalescer) mark() { c.pending = true }
+
+func (c *coalescer) take() bool {
+	if c.pending {
+		c.pending = false
+		return true
+	}
+	return false
+}
+
+// clearStreamDeadlines removes the server's per-connection read AND write
+// deadlines for a long-lived SSE response. The http.Server's WriteTimeout
+// otherwise fails the next event write once it elapses; ReadTimeout is cleared
+// too for defence in depth. Datastar reconnects on each drop and, after its
+// retry budget, gives up — so a stale deadline silently stops live updates.
+func clearStreamDeadlines(w http.ResponseWriter) {
+	rc := http.NewResponseController(w)
+	_ = rc.SetReadDeadline(time.Time{})
+	_ = rc.SetWriteDeadline(time.Time{})
+}
+
+// handleDomainsStream is the live-update SSE stream for the domains list. It
+// subscribes to the caller's tenant scope and, when a scan writes observations
+// (or a domain is created/deleted/updated), re-renders the grouped rows of
+// #domains-rows in place — the same patch handleDomainCreate uses. Renders are
+// coalesced so an enumeration burst collapses to one patch per interval.
+//
+// The grouping/layout match the page default (nested); the in-memory TLD filter
+// and search are client-only state the stream cannot see, so a live refresh
+// resets to the unfiltered nested view — identical to how the create flow
+// already re-renders. It patches only the rows container, never the signal-scope
+// root, so it cannot re-trigger the stream opener.
+func (h *Handlers) handleDomainsStream(w http.ResponseWriter, r *http.Request) {
+	p, ok := PrincipalFrom(r.Context())
+	if !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	clearStreamDeadlines(w)
+	csrf := CSRFTokenFrom(r.Context())
+	canManage := service.OwnerOrManager(p)
+
+	sse := datastar.NewSSE(w, r)
+	scope := observationScope(p.TenantID)
+	subID, events := h.broker.Subscribe(scope)
+	defer h.broker.Unsubscribe(scope, subID)
+
+	var pending coalescer
+	coalesce := time.NewTicker(coalesceInterval)
+	defer coalesce.Stop()
+	keepAlive := time.NewTicker(keepAliveInterval)
+	defer keepAlive.Stop()
+	var beat int
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-keepAlive.C:
+			beat++
+			if err := sse.MarshalAndPatchSignals(map[string]any{"_ka": beat}); err != nil {
+				return
+			}
+		case <-coalesce.C:
+			if !pending.take() {
+				continue
+			}
+			rows, err := h.listDomainRows(r.Context(), p)
+			if err != nil {
+				h.log.Error("domains stream: list rows", "error", err)
+				continue
+			}
+			if err := sse.PatchElementTempl(
+				templates.DomainTableBody(templates.DomainsPageProps{
+					Layout:  "nested",
+					Domains: rows,
+					Groups:  groupDomainsByApex(rows),
+				}, csrf, canManage),
+				datastar.WithSelectorID("domains-rows"),
+				datastar.WithModeInner(),
+			); err != nil {
+				return
+			}
+		case _, ok := <-events:
+			if !ok {
+				return
+			}
+			pending.mark()
+		}
+	}
+}
+
+// handleDomainDetailStream is the live-update SSE stream for one domain's detail
+// page. It subscribes to the caller's tenant scope and, for events matching this
+// domain, re-renders the records, timeline, and findings panels (coalesced) as a
+// scan writes observations. Containers for inactive tabs are present in the DOM,
+// so the morph keeps whichever tab the user is viewing current. Unlike the list,
+// these panels carry no client-only view state, so the server renders them
+// directly.
+func (h *Handlers) handleDomainDetailStream(w http.ResponseWriter, r *http.Request) {
+	p, ok := PrincipalFrom(r.Context())
+	if !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	uid := chi.URLParam(r, "uid")
+
+	clearStreamDeadlines(w)
+
+	sse := datastar.NewSSE(w, r)
+	scope := observationScope(p.TenantID)
+	subID, events := h.broker.Subscribe(scope)
+	defer h.broker.Unsubscribe(scope, subID)
+
+	var pending coalescer
+	coalesce := time.NewTicker(coalesceInterval)
+	defer coalesce.Stop()
+	keepAlive := time.NewTicker(keepAliveInterval)
+	defer keepAlive.Stop()
+	var beat int
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-keepAlive.C:
+			beat++
+			if err := sse.MarshalAndPatchSignals(map[string]any{"_ka": beat}); err != nil {
+				return
+			}
+		case <-coalesce.C:
+			if !pending.take() {
+				continue
+			}
+			ctx := r.Context()
+			h.patchRecordsContent(ctx, sse, p, uid)
+			h.patchTimelineContent(ctx, sse, p, uid)
+			h.patchTimelineFullContent(ctx, sse, p, uid, "")
+			h.patchFindingsContent(ctx, sse, p, uid)
+		case evt, ok := <-events:
+			if !ok {
+				return
+			}
+			// Tenant scope carries every domain's events; this stream only cares
+			// about the domain it is rendering.
+			if evt.DomainUID == uid {
+				pending.mark()
+			}
+		}
+	}
+}

--- a/internal/ui/stream_test.go
+++ b/internal/ui/stream_test.go
@@ -1,0 +1,85 @@
+package ui
+
+import (
+	"bufio"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A long-lived SSE response must survive past the server's ReadTimeout and
+// WriteTimeout — both default to 5s here, and either one silently aborts the
+// stream (write fails the next event; read cancels the request context). The
+// stream handlers call clearStreamDeadlines to defeat both; this proves it.
+func TestClearStreamDeadlinesSurvivesServerTimeouts(t *testing.T) {
+	t.Parallel()
+
+	const (
+		serverTimeout = 200 * time.Millisecond
+		tick          = 80 * time.Millisecond
+		ticks         = 10
+	)
+	h := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		clearStreamDeadlines(w)
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Error("ResponseWriter is not a Flusher")
+			return
+		}
+		for i := 0; i < ticks; i++ {
+			_, _ = fmt.Fprintf(w, "data: %d\n\n", i)
+			flusher.Flush()
+			time.Sleep(tick)
+		}
+	})
+
+	srv := httptest.NewUnstartedServer(h)
+	srv.Config.ReadTimeout = serverTimeout
+	srv.Config.WriteTimeout = serverTimeout
+	srv.Start()
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	got := 0
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		if strings.HasPrefix(scanner.Text(), "data:") {
+			got++
+		}
+	}
+	// Events 0-2 land within the 200ms timeout window; receiving well past that
+	// (>=6, i.e. up to ~480ms in) proves the connection was not torn down.
+	if got < 6 {
+		t.Fatalf("received %d events before the stream died; want >=6 (timeouts not cleared)", got)
+	}
+}
+
+// A burst of events between ticks must collapse to a single refresh: many
+// mark() calls yield exactly one take()==true, and an idle interval yields none.
+func TestCoalescerCollapsesBurst(t *testing.T) {
+	t.Parallel()
+	var c coalescer
+
+	if c.take() {
+		t.Fatal("idle coalescer should not be pending")
+	}
+
+	c.mark()
+	c.mark()
+	c.mark()
+	if !c.take() {
+		t.Fatal("a marked coalescer should take once")
+	}
+	if c.take() {
+		t.Fatal("a coalescer should not take twice without a new mark")
+	}
+}

--- a/internal/ui/templates/domain_detail.templ
+++ b/internal/ui/templates/domain_detail.templ
@@ -6,6 +6,9 @@ templ DomainDetailPage(props DomainDetailPageProps) {
 	@Page("gecko · " + props.Name) {
 		@AppShell(props.Shell) {
 			<div data-signals={ detailSignals(props.InitialTab) }>
+				// Dedicated element so a tab's lazy-load @get cannot cancel the
+				// long-lived scan stream.
+				<div data-init={ "@get('/app/domains/" + props.UID + "/stream', {requestCancellation: 'disabled'})" }></div>
 				<div class="detail-head">
 					<a class="back" href="/app/domains">← domains</a>
 				</div>

--- a/internal/ui/templates/domain_detail_templ.go
+++ b/internal/ui/templates/domain_detail_templ.go
@@ -68,237 +68,250 @@ func DomainDetailPage(props DomainDetailPageProps) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "\"><div class=\"detail-head\"><a class=\"back\" href=\"/app/domains\">← domains</a></div><div class=\"detail-title\"><span class=\"sdot\" style=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "\"><div data-init=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var5 string
-				templ_7745c5c3_Var5, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues("background:var(--" + props.Severity + ")")
+				templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs("@get('/app/domains/" + props.UID + "/stream', {requestCancellation: 'disabled'})")
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 13, Col: 74}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 11, Col: 103}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "\"></span><h1>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "\"></div><div class=\"detail-head\"><a class=\"back\" href=\"/app/domains\">← domains</a></div><div class=\"detail-title\"><span class=\"sdot\" style=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var6 string
-				templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(props.Name)
+				templ_7745c5c3_Var6, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues("background:var(--" + props.Severity + ")")
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 14, Col: 21}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 16, Col: 74}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</h1>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "\"></span><h1>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var7 string
+				templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(props.Name)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 17, Col: 21}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</h1>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				if props.FindingsCount != "" && props.FindingsCount != "0" {
-					var templ_7745c5c3_Var7 = []any{"badge", props.FindingsSeverity}
-					templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var7...)
+					var templ_7745c5c3_Var8 = []any{"badge", props.FindingsSeverity}
+					templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var8...)
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<span class=\"")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					var templ_7745c5c3_Var8 string
-					templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var7).String())
-					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 1, Col: 0}
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<span class=\"")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var9 string
-					templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(props.FindingsCount)
+					templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var8).String())
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 16, Col: 75}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 1, Col: 0}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, " findings</span> ")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "\">")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var10 string
+					templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(props.FindingsCount)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 19, Col: 75}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, " findings</span> ")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<span class=\"badge info\">")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var10 string
-				templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(props.RecordCount)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 18, Col: 49}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, " records</span></div><div class=\"page-head\" style=\"margin-top:-6px\"><div class=\"sub\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<span class=\"badge info\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var11 string
-				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(props.Type)
+				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(props.RecordCount)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 21, Col: 34}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 21, Col: 49}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, " · ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, " records</span></div><div class=\"page-head\" style=\"margin-top:-6px\"><div class=\"sub\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var12 string
-				templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(props.Source)
+				templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(props.Type)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 21, Col: 54}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 24, Col: 34}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, " · added ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, " · ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var13 string
-				templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(props.Added)
+				templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(props.Source)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 21, Col: 79}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 24, Col: 54}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, " · scanned ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, " · added ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var14 string
-				templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(props.Scanned)
+				templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(props.Added)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 21, Col: 108}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 24, Col: 79}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "</div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, " · scanned ")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var15 string
+				templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(props.Scanned)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 24, Col: 108}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				if props.Shell.CanManageDomains {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<button class=\"btn\" type=\"button\" data-on:click=\"")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<button class=\"btn\" type=\"button\" data-on:click=\"")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					var templ_7745c5c3_Var15 string
-					templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(postWithCSRF("/app/domains/"+props.UID+"/rescan", props.Shell.CSRFToken))
+					var templ_7745c5c3_Var16 string
+					templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(postWithCSRF("/app/domains/"+props.UID+"/rescan", props.Shell.CSRFToken))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 26, Col: 95}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 29, Col: 95}
 					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "\">⟳ Rescan</button>")
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "\">⟳ Rescan</button>")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</div><div class=\"tabs\"><a data-on:click__prevent=\"$tab = 'records'\" data-class=\"{'active': $tab === 'records'}\">Records</a> <a data-on:click__prevent=\"")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var16 string
-				templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs("$tab='timeline'; if(!$tlLoaded){$tlLoaded=true; @get('/app/domains/" + props.UID + "/timeline/full')}")
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 33, Col: 134}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "\" data-class=\"{'active': $tab === 'timeline'}\">Timeline</a> <a data-on:click__prevent=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "</div><div class=\"tabs\"><a data-on:click__prevent=\"$tab = 'records'\" data-class=\"{'active': $tab === 'records'}\">Records</a> <a data-on:click__prevent=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var17 string
-				templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs("$tab='findings'; if(!$fnLoaded){$fnLoaded=true; @get('/app/domains/" + props.UID + "/findings')}")
+				templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs("$tab='timeline'; if(!$tlLoaded){$tlLoaded=true; @get('/app/domains/" + props.UID + "/timeline/full')}")
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 37, Col: 129}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 36, Col: 134}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "\" data-class=\"{'active': $tab === 'findings'}\">Findings ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "\" data-class=\"{'active': $tab === 'timeline'}\">Timeline</a> <a data-on:click__prevent=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var18 string
+				templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs("$tab='findings'; if(!$fnLoaded){$fnLoaded=true; @get('/app/domains/" + props.UID + "/findings')}")
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 40, Col: 129}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "\" data-class=\"{'active': $tab === 'findings'}\">Findings ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				if props.FindingsCount != "" && props.FindingsCount != "0" {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<span style=\"")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					var templ_7745c5c3_Var18 string
-					templ_7745c5c3_Var18, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues("color:var(--" + props.FindingsSeverity + ")")
-					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 42, Col: 66}
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "\">·")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<span style=\"")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var19 string
-					templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(props.FindingsCount)
+					templ_7745c5c3_Var19, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues("color:var(--" + props.FindingsSeverity + ")")
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 42, Col: 92}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 45, Col: 66}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "</span>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "\">·")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var20 string
+					templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(props.FindingsCount)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 45, Col: 92}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "</span>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "</a></div><div class=\"detail-grid\" style=\"display:none\" data-show=\"$tab === 'records'\"><div class=\"panel\" id=\"records-panel\"><div id=\"records-content\" data-on-intersect__once=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "</a></div><div class=\"detail-grid\" style=\"display:none\" data-show=\"$tab === 'records'\"><div class=\"panel\" id=\"records-panel\"><div id=\"records-content\" data-on-intersect__once=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var20 string
-				templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs("@get('/app/domains/" + props.UID + "/records')")
+				var templ_7745c5c3_Var21 string
+				templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs("@get('/app/domains/" + props.UID + "/records')")
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 50, Col: 81}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 53, Col: 81}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "\"><div class=\"panel-h\">DNS records <span class=\"count\">loading…</span></div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "\"><div class=\"panel-h\">DNS records <span class=\"count\">loading…</span></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -306,20 +319,20 @@ func DomainDetailPage(props DomainDetailPageProps) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "</div></div><div class=\"panel\" id=\"timeline-panel\"><div id=\"timeline-content\" data-on-intersect__once=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "</div></div><div class=\"panel\" id=\"timeline-panel\"><div id=\"timeline-content\" data-on-intersect__once=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var21 string
-				templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs("@get('/app/domains/" + props.UID + "/timeline')")
+				var templ_7745c5c3_Var22 string
+				templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs("@get('/app/domains/" + props.UID + "/timeline')")
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 59, Col: 82}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 62, Col: 82}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "\"><div class=\"panel-h\">Change timeline <span class=\"count\">loading…</span></div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "\"><div class=\"panel-h\">Change timeline <span class=\"count\">loading…</span></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -327,25 +340,25 @@ func DomainDetailPage(props DomainDetailPageProps) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "</div></div></div><div style=\"display:none\" data-show=\"$tab === 'timeline'\"><div class=\"panel\" id=\"timeline-full-panel\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "</div></div></div><div style=\"display:none\" data-show=\"$tab === 'timeline'\"><div class=\"panel\" id=\"timeline-full-panel\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				if props.InitialTab == "timeline" {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<div id=\"timeline-full-content\" data-on-intersect__once=\"")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "<div id=\"timeline-full-content\" data-on-intersect__once=\"")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					var templ_7745c5c3_Var22 string
-					templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(timelineFullLoad(props.UID, props.InitialScan))
+					var templ_7745c5c3_Var23 string
+					templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(timelineFullLoad(props.UID, props.InitialScan))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 71, Col: 80}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 74, Col: 80}
 					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "\"><div class=\"panel-h\">Change timeline <span class=\"count\">loading…</span></div>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "\"><div class=\"panel-h\">Change timeline <span class=\"count\">loading…</span></div>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -353,12 +366,12 @@ func DomainDetailPage(props DomainDetailPageProps) templ.Component {
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "</div>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "</div>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				} else {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "<div id=\"timeline-full-content\"><div class=\"panel-h\">Change timeline <span class=\"count\">loading…</span></div>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<div id=\"timeline-full-content\"><div class=\"panel-h\">Change timeline <span class=\"count\">loading…</span></div>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -366,12 +379,12 @@ func DomainDetailPage(props DomainDetailPageProps) templ.Component {
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "</div>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</div>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</div></div><div style=\"display:none\" data-show=\"$tab === 'findings'\"><div id=\"findings-content\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "</div></div><div style=\"display:none\" data-show=\"$tab === 'findings'\"><div id=\"findings-content\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -379,7 +392,7 @@ func DomainDetailPage(props DomainDetailPageProps) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "</div></div></div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "</div></div></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -415,12 +428,12 @@ func recordsSkeleton() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var23 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var23 == nil {
-			templ_7745c5c3_Var23 = templ.NopComponent
+		templ_7745c5c3_Var24 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var24 == nil {
+			templ_7745c5c3_Var24 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "<div style=\"padding:16px\"><div style=\"height:16px;background:var(--panel-2);border-radius:4px;margin-bottom:10px;width:80%\"></div><div style=\"height:16px;background:var(--panel-2);border-radius:4px;margin-bottom:10px;width:60%\"></div><div style=\"height:16px;background:var(--panel-2);border-radius:4px;margin-bottom:10px;width:70%\"></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "<div style=\"padding:16px\"><div style=\"height:16px;background:var(--panel-2);border-radius:4px;margin-bottom:10px;width:80%\"></div><div style=\"height:16px;background:var(--panel-2);border-radius:4px;margin-bottom:10px;width:60%\"></div><div style=\"height:16px;background:var(--panel-2);border-radius:4px;margin-bottom:10px;width:70%\"></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -444,12 +457,12 @@ func timelineSkeleton() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var24 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var24 == nil {
-			templ_7745c5c3_Var24 = templ.NopComponent
+		templ_7745c5c3_Var25 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var25 == nil {
+			templ_7745c5c3_Var25 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "<div style=\"padding:16px\"><div style=\"height:16px;background:var(--panel-2);border-radius:4px;margin-bottom:10px;width:75%\"></div><div style=\"height:16px;background:var(--panel-2);border-radius:4px;margin-bottom:10px;width:55%\"></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "<div style=\"padding:16px\"><div style=\"height:16px;background:var(--panel-2);border-radius:4px;margin-bottom:10px;width:75%\"></div><div style=\"height:16px;background:var(--panel-2);border-radius:4px;margin-bottom:10px;width:55%\"></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -473,69 +486,69 @@ func RecordsTable(v RecordsView) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var25 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var25 == nil {
-			templ_7745c5c3_Var25 = templ.NopComponent
+		templ_7745c5c3_Var26 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var26 == nil {
+			templ_7745c5c3_Var26 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "<div class=\"panel-h\">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var26 string
-		templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(v.Title)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 110, Col: 31}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, " <span class=\"count\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "<div class=\"panel-h\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var27 string
-		templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(v.Count)
+		templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(v.Title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 110, Col: 63}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 113, Col: 31}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "</span></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, " <span class=\"count\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var28 string
+		templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(v.Count)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 113, Col: 63}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "</span></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		for _, r := range v.Rows {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "<div class=\"rec\"><span class=\"type\">")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var28 string
-			templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(r.Type)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 113, Col: 30}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "</span> <span class=\"val\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "<div class=\"rec\"><span class=\"type\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var29 string
-			templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinStringErrs(r.Value)
+			templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinStringErrs(r.Type)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 114, Col: 30}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 116, Col: 30}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var29))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "</span></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "</span> <span class=\"val\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var30 string
+			templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs(r.Value)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 117, Col: 30}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "</span></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -560,66 +573,66 @@ func Timeline(v TimelineView) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var30 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var30 == nil {
-			templ_7745c5c3_Var30 = templ.NopComponent
+		templ_7745c5c3_Var31 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var31 == nil {
+			templ_7745c5c3_Var31 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "<div class=\"panel-h\">Change timeline <span class=\"count\">grouped by scan</span></div><div class=\"tl\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "<div class=\"panel-h\">Change timeline <span class=\"count\">grouped by scan</span></div><div class=\"tl\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		for _, item := range v.Groups {
-			var templ_7745c5c3_Var31 = []any{"tl-item", item.Kind}
-			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var31...)
+			var templ_7745c5c3_Var32 = []any{"tl-item", item.Kind}
+			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var32...)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "<div class=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var32 string
-			templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var31).String())
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 1, Col: 0}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "\"><span class=\"dot\"></span><div class=\"when\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "<div class=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var33 string
-			templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(item.When)
+			templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var32).String())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 125, Col: 33}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 1, Col: 0}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "</div><div class=\"what\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "\"><span class=\"dot\"></span><div class=\"when\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var34 string
-			templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs(item.What)
+			templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs(item.When)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 126, Col: 33}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 128, Col: 33}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var34))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "</div></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "</div><div class=\"what\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var35 string
+			templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.JoinStringErrs(item.What)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 129, Col: 33}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var35))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "</div></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -645,182 +658,182 @@ func TimelineFull(v TimelineFullView) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var35 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var35 == nil {
-			templ_7745c5c3_Var35 = templ.NopComponent
+		templ_7745c5c3_Var36 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var36 == nil {
+			templ_7745c5c3_Var36 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "<div class=\"panel-h\">Change timeline <span class=\"count\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "<div class=\"panel-h\">Change timeline <span class=\"count\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var36 string
-		templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d scans · %d changes", v.ScanCount, v.ChangeCount))
+		var templ_7745c5c3_Var37 string
+		templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d scans · %d changes", v.ScanCount, v.ChangeCount))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 136, Col: 105}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 139, Col: 105}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var36))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var37))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "</span></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "</span></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if len(v.Groups) == 0 {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "<div class=\"trow-empty\">no changes recorded yet</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "<div class=\"trow-empty\">no changes recorded yet</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "<div class=\"tlx\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "<div class=\"tlx\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			for _, g := range v.Groups {
-				var templ_7745c5c3_Var37 = []any{"scan-grp", templ.KV("highlight", g.Highlighted)}
-				templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var37...)
+				var templ_7745c5c3_Var38 = []any{"scan-grp", templ.KV("highlight", g.Highlighted)}
+				templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var38...)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "<div class=\"")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var38 string
-				templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var37).String())
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 1, Col: 0}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var38))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "\"><div class=\"scan-hd\"><span class=\"m\"></span><div><div class=\"nm\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "<div class=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var39 string
-				templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinStringErrs(g.ScanID)
+				templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var38).String())
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 147, Col: 33}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 1, Col: 0}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var39))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "</div><div class=\"mt\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "\"><div class=\"scan-hd\"><span class=\"m\"></span><div><div class=\"nm\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var40 string
-				templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.JoinStringErrs(g.When)
+				templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.JoinStringErrs(g.ScanID)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 148, Col: 31}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 150, Col: 33}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var40))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, " · ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "</div><div class=\"mt\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var41 string
-				templ_7745c5c3_Var41, templ_7745c5c3_Err = templ.JoinStringErrs(g.Meta)
+				templ_7745c5c3_Var41, templ_7745c5c3_Err = templ.JoinStringErrs(g.When)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 148, Col: 45}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 151, Col: 31}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var41))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "</div></div><span class=\"cb\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, " · ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var42 string
-				templ_7745c5c3_Var42, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d changes", g.ChangeCount))
+				templ_7745c5c3_Var42, templ_7745c5c3_Err = templ.JoinStringErrs(g.Meta)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 150, Col: 65}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 151, Col: 45}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var42))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, "</span></div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, "</div></div><span class=\"cb\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var43 string
+				templ_7745c5c3_Var43, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d changes", g.ChangeCount))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 153, Col: 65}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var43))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, "</span></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				for _, ch := range g.Changes {
-					var templ_7745c5c3_Var43 = []any{"chg", ch.Kind}
-					templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var43...)
+					var templ_7745c5c3_Var44 = []any{"chg", ch.Kind}
+					templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var44...)
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, "<div class=\"")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					var templ_7745c5c3_Var44 string
-					templ_7745c5c3_Var44, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var43).String())
-					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 1, Col: 0}
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var44))
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, "\"><span class=\"op\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, "<div class=\"")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var45 string
-					templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.JoinStringErrs(ch.Op)
+					templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var44).String())
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 154, Col: 31}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 1, Col: 0}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var45))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 60, "</span> <span class=\"ent\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 60, "\"><span class=\"op\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var46 string
-					templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.JoinStringErrs(ch.Entity)
+					templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.JoinStringErrs(ch.Op)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 155, Col: 36}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 157, Col: 31}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var46))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 61, "</span> <span class=\"cv\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 61, "</span> <span class=\"ent\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var47 string
-					templ_7745c5c3_Var47, templ_7745c5c3_Err = templ.JoinStringErrs(ch.Value)
+					templ_7745c5c3_Var47, templ_7745c5c3_Err = templ.JoinStringErrs(ch.Entity)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 156, Col: 34}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 158, Col: 36}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var47))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, "</span></div>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, "</span> <span class=\"cv\">")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var48 string
+					templ_7745c5c3_Var48, templ_7745c5c3_Err = templ.JoinStringErrs(ch.Value)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 159, Col: 34}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var48))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 63, "</span></div>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 63, "</div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 64, "</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 64, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 65, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -847,79 +860,60 @@ func FindingsPanel(v FindingsView) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var48 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var48 == nil {
-			templ_7745c5c3_Var48 = templ.NopComponent
+		templ_7745c5c3_Var49 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var49 == nil {
+			templ_7745c5c3_Var49 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		if v.TotalCount == 0 {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 65, "<div class=\"trow-empty\">no findings yet — run a scan to assess this domain</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 66, "<div class=\"trow-empty\">no findings yet — run a scan to assess this domain</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 66, "<div class=\"f-assessed\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 67, "<div class=\"f-assessed\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var49 string
-			templ_7745c5c3_Var49, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d checks · %d critical · %d warnings · %d healthy", v.TotalCount, v.CriticalCount, v.WarningCount, v.HealthyCount))
+			var templ_7745c5c3_Var50 string
+			templ_7745c5c3_Var50, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d checks · %d critical · %d warnings · %d healthy", v.TotalCount, v.CriticalCount, v.WarningCount, v.HealthyCount))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 172, Col: 136}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 175, Col: 136}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var49))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var50))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 67, "</div><div class=\"find-sum\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 68, "</div><div class=\"find-sum\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if v.CriticalCount > 0 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 68, "<div class=\"s c\"><i></i> <b>")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var50 string
-				templ_7745c5c3_Var50, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", v.CriticalCount))
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 176, Col: 68}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var50))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 69, "</b> critical</div>")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-			}
-			if v.WarningCount > 0 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 70, "<div class=\"s w\"><i></i> <b>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 69, "<div class=\"s c\"><i></i> <b>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var51 string
-				templ_7745c5c3_Var51, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", v.WarningCount))
+				templ_7745c5c3_Var51, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", v.CriticalCount))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 179, Col: 67}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 179, Col: 68}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var51))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 71, "</b> warnings</div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 70, "</b> critical</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			if v.HealthyCount > 0 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 72, "<div class=\"s o\"><i></i> <b>")
+			if v.WarningCount > 0 {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 71, "<div class=\"s w\"><i></i> <b>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var52 string
-				templ_7745c5c3_Var52, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", v.HealthyCount))
+				templ_7745c5c3_Var52, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", v.WarningCount))
 				if templ_7745c5c3_Err != nil {
 					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 182, Col: 67}
 				}
@@ -927,157 +921,176 @@ func FindingsPanel(v FindingsView) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 73, "</b> healthy</div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 72, "</b> warnings</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 74, "</div>")
+			if v.HealthyCount > 0 {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 73, "<div class=\"s o\"><i></i> <b>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var53 string
+				templ_7745c5c3_Var53, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", v.HealthyCount))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 185, Col: 67}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var53))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 74, "</b> healthy</div>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 75, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			for _, f := range v.Findings {
-				var templ_7745c5c3_Var53 = []any{"finding", "f-" + f.SevClass}
-				templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var53...)
+				var templ_7745c5c3_Var54 = []any{"finding", "f-" + f.SevClass}
+				templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var54...)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 75, "<div class=\"")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var54 string
-				templ_7745c5c3_Var54, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var53).String())
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 1, Col: 0}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var54))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 76, "\"><div class=\"f-ico\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 76, "<div class=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var55 string
-				templ_7745c5c3_Var55, templ_7745c5c3_Err = templ.JoinStringErrs(f.Icon)
+				templ_7745c5c3_Var55, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var54).String())
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 187, Col: 31}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 1, Col: 0}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var55))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 77, "</div><div><div class=\"f-top\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 77, "\"><div class=\"f-ico\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var56 = []any{"badge", f.SevClass}
-				templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var56...)
+				var templ_7745c5c3_Var56 string
+				templ_7745c5c3_Var56, templ_7745c5c3_Err = templ.JoinStringErrs(f.Icon)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 190, Col: 31}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var56))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 78, "<span class=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 78, "</div><div><div class=\"f-top\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var57 string
-				templ_7745c5c3_Var57, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var56).String())
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 1, Col: 0}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var57))
+				var templ_7745c5c3_Var57 = []any{"badge", f.SevClass}
+				templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var57...)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 79, "\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 79, "<span class=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var58 string
-				templ_7745c5c3_Var58, templ_7745c5c3_Err = templ.JoinStringErrs(f.Severity)
+				templ_7745c5c3_Var58, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var57).String())
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 190, Col: 54}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 1, Col: 0}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var58))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 80, "</span><h4>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 80, "\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var59 string
-				templ_7745c5c3_Var59, templ_7745c5c3_Err = templ.JoinStringErrs(f.Title)
+				templ_7745c5c3_Var59, templ_7745c5c3_Err = templ.JoinStringErrs(f.Severity)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 191, Col: 19}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 193, Col: 54}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var59))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 81, "</h4></div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 81, "</span><h4>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var60 string
+				templ_7745c5c3_Var60, templ_7745c5c3_Err = templ.JoinStringErrs(f.Title)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 194, Col: 19}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var60))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 82, "</h4></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				if f.Description != "" {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 82, "<p>")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					var templ_7745c5c3_Var60 string
-					templ_7745c5c3_Var60, templ_7745c5c3_Err = templ.JoinStringErrs(f.Description)
-					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 194, Col: 24}
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var60))
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 83, "</p>")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-				}
-				if f.Evidence != "" {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 84, "<div class=\"f-ev\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 83, "<p>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var61 string
-					templ_7745c5c3_Var61, templ_7745c5c3_Err = templ.JoinStringErrs(f.Evidence)
+					templ_7745c5c3_Var61, templ_7745c5c3_Err = templ.JoinStringErrs(f.Description)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 197, Col: 36}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 197, Col: 24}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var61))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 85, "</div>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 84, "</p>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				}
-				if f.FixHint != "" {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 86, "<div class=\"f-fix\">→ <b>Fix:</b> ")
+				if f.Evidence != "" {
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 85, "<div class=\"f-ev\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var62 string
-					templ_7745c5c3_Var62, templ_7745c5c3_Err = templ.JoinStringErrs(f.FixHint)
+					templ_7745c5c3_Var62, templ_7745c5c3_Err = templ.JoinStringErrs(f.Evidence)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 200, Col: 52}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 200, Col: 36}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var62))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 87, "</div>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 86, "</div>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 88, "</div></div>")
+				if f.FixHint != "" {
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 87, "<div class=\"f-fix\">→ <b>Fix:</b> ")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var63 string
+					templ_7745c5c3_Var63, templ_7745c5c3_Err = templ.JoinStringErrs(f.FixHint)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domain_detail.templ`, Line: 203, Col: 52}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var63))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 88, "</div>")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 89, "</div></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}

--- a/internal/ui/templates/domains.templ
+++ b/internal/ui/templates/domains.templ
@@ -4,6 +4,9 @@ templ DomainsPage(props DomainsPageProps) {
 	@Page("gecko · Domains") {
 		@AppShell(props.Shell) {
 			<div data-signals='{"q":"","newDomain":"","drawerOpen":false,"layout":"nested","tld":"","collapsed":[],"offset":0}'>
+				// A dedicated element opens the long-lived live-update stream, kept off
+				// the signals div so the search/layout @get actions can't cancel it.
+				<div data-init="@get('/app/domains/stream', {requestCancellation: 'disabled'})"></div>
 				<div class="page-head">
 					<div>
 						<h1>Domains</h1>

--- a/internal/ui/templates/domains_templ.go
+++ b/internal/ui/templates/domains_templ.go
@@ -53,14 +53,14 @@ func DomainsPage(props DomainsPageProps) templ.Component {
 					}()
 				}
 				ctx = templ.InitializeContext(ctx)
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div data-signals='{\"q\":\"\",\"newDomain\":\"\",\"drawerOpen\":false,\"layout\":\"nested\",\"tld\":\"\",\"collapsed\":[],\"offset\":0}'><div class=\"page-head\"><div><h1>Domains</h1><div class=\"sub\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div data-signals='{\"q\":\"\",\"newDomain\":\"\",\"drawerOpen\":false,\"layout\":\"nested\",\"tld\":\"\",\"collapsed\":[],\"offset\":0}'><div data-init=\"@get('/app/domains/stream', {requestCancellation: 'disabled'})\"></div><div class=\"page-head\"><div><h1>Domains</h1><div class=\"sub\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var4 string
 				templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(props.Stats.Tracked)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 11, Col: 28}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 14, Col: 28}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 				if templ_7745c5c3_Err != nil {
@@ -73,7 +73,7 @@ func DomainsPage(props DomainsPageProps) templ.Component {
 				var templ_7745c5c3_Var5 string
 				templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(props.Stats.Critical)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 11, Col: 64}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 14, Col: 64}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 				if templ_7745c5c3_Err != nil {
@@ -86,7 +86,7 @@ func DomainsPage(props DomainsPageProps) templ.Component {
 				var templ_7745c5c3_Var6 string
 				templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(props.Stats.Warnings)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 11, Col: 101}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 14, Col: 101}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 				if templ_7745c5c3_Err != nil {
@@ -104,7 +104,7 @@ func DomainsPage(props DomainsPageProps) templ.Component {
 					var templ_7745c5c3_Var7 string
 					templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(postWithConfirm("Rescan all tracked domains?", "/app/domains/rescan", props.Shell.CSRFToken))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 18, Col: 115}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 21, Col: 115}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 					if templ_7745c5c3_Err != nil {
@@ -122,7 +122,7 @@ func DomainsPage(props DomainsPageProps) templ.Component {
 				var templ_7745c5c3_Var8 string
 				templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(props.Stats.Tracked)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 25, Col: 42}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 28, Col: 42}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 				if templ_7745c5c3_Err != nil {
@@ -135,7 +135,7 @@ func DomainsPage(props DomainsPageProps) templ.Component {
 				var templ_7745c5c3_Var9 string
 				templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(props.Stats.Critical)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 29, Col: 43}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 32, Col: 43}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 				if templ_7745c5c3_Err != nil {
@@ -148,7 +148,7 @@ func DomainsPage(props DomainsPageProps) templ.Component {
 				var templ_7745c5c3_Var10 string
 				templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(props.Stats.Warnings)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 33, Col: 43}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 36, Col: 43}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 				if templ_7745c5c3_Err != nil {
@@ -161,7 +161,7 @@ func DomainsPage(props DomainsPageProps) templ.Component {
 				var templ_7745c5c3_Var11 string
 				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(props.Stats.Records)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 37, Col: 42}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 40, Col: 42}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 				if templ_7745c5c3_Err != nil {
@@ -179,7 +179,7 @@ func DomainsPage(props DomainsPageProps) templ.Component {
 					var templ_7745c5c3_Var12 string
 					templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(t)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 54, Col: 25}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 57, Col: 25}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 					if templ_7745c5c3_Err != nil {
@@ -192,7 +192,7 @@ func DomainsPage(props DomainsPageProps) templ.Component {
 					var templ_7745c5c3_Var13 string
 					templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(t)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 54, Col: 31}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 57, Col: 31}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 					if templ_7745c5c3_Err != nil {
@@ -220,7 +220,7 @@ func DomainsPage(props DomainsPageProps) templ.Component {
 				var templ_7745c5c3_Var14 string
 				templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(props.Stats.Tracked)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 78, Col: 67}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 81, Col: 67}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 				if templ_7745c5c3_Err != nil {
@@ -250,7 +250,7 @@ func DomainsPage(props DomainsPageProps) templ.Component {
 					var templ_7745c5c3_Var15 string
 					templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(postWithCSRF("/app/domains", props.Shell.CSRFToken))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 114, Col: 75}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 117, Col: 75}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 					if templ_7745c5c3_Err != nil {
@@ -420,7 +420,7 @@ func DomainGroupRow(g DomainGroupView, csrfToken string, canManage bool) templ.C
 		var templ_7745c5c3_Var21 string
 		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(collapsedClass(g.Apex))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 158, Col: 37}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 161, Col: 37}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 		if templ_7745c5c3_Err != nil {
@@ -433,7 +433,7 @@ func DomainGroupRow(g DomainGroupView, csrfToken string, canManage bool) templ.C
 		var templ_7745c5c3_Var22 string
 		templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(toggleCollapse(g.Apex))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 159, Col: 40}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 162, Col: 40}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 		if templ_7745c5c3_Err != nil {
@@ -451,7 +451,7 @@ func DomainGroupRow(g DomainGroupView, csrfToken string, canManage bool) templ.C
 			var templ_7745c5c3_Var23 templ.SafeURL
 			templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("/app/domains/" + g.Header.UID))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 166, Col: 57}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 169, Col: 57}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 			if templ_7745c5c3_Err != nil {
@@ -464,7 +464,7 @@ func DomainGroupRow(g DomainGroupView, csrfToken string, canManage bool) templ.C
 			var templ_7745c5c3_Var24 string
 			templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(g.Apex)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 170, Col: 16}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 173, Col: 16}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
 			if templ_7745c5c3_Err != nil {
@@ -482,7 +482,7 @@ func DomainGroupRow(g DomainGroupView, csrfToken string, canManage bool) templ.C
 			var templ_7745c5c3_Var25 string
 			templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(g.Apex)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 172, Col: 31}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 175, Col: 31}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 			if templ_7745c5c3_Err != nil {
@@ -501,7 +501,7 @@ func DomainGroupRow(g DomainGroupView, csrfToken string, canManage bool) templ.C
 			var templ_7745c5c3_Var26 string
 			templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(subLabel(g.SubCount))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 175, Col: 49}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 178, Col: 49}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
 			if templ_7745c5c3_Err != nil {
@@ -523,7 +523,7 @@ func DomainGroupRow(g DomainGroupView, csrfToken string, canManage bool) templ.C
 		var templ_7745c5c3_Var27 string
 		templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(g.Header.RecordCount)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 179, Col: 48}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 182, Col: 48}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
 		if templ_7745c5c3_Err != nil {
@@ -564,7 +564,7 @@ func DomainGroupRow(g DomainGroupView, csrfToken string, canManage bool) templ.C
 		var templ_7745c5c3_Var30 string
 		templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs(g.FindingsLabel)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 185, Col: 21}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 188, Col: 21}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
 		if templ_7745c5c3_Err != nil {
@@ -577,7 +577,7 @@ func DomainGroupRow(g DomainGroupView, csrfToken string, canManage bool) templ.C
 		var templ_7745c5c3_Var31 string
 		templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs(g.Header.LastScan)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 188, Col: 45}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 191, Col: 45}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
 		if templ_7745c5c3_Err != nil {
@@ -646,7 +646,7 @@ func DomainChildRow(c DomainRowView, apex string, last bool, csrfToken string, c
 		var templ_7745c5c3_Var35 string
 		templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.JoinStringErrs("domain-row-" + c.UID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 202, Col: 28}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 205, Col: 28}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var35))
 		if templ_7745c5c3_Err != nil {
@@ -659,7 +659,7 @@ func DomainChildRow(c DomainRowView, apex string, last bool, csrfToken string, c
 		var templ_7745c5c3_Var36 string
 		templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinStringErrs(notCollapsed(apex))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 203, Col: 32}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 206, Col: 32}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var36))
 		if templ_7745c5c3_Err != nil {
@@ -672,7 +672,7 @@ func DomainChildRow(c DomainRowView, apex string, last bool, csrfToken string, c
 		var templ_7745c5c3_Var37 templ.SafeURL
 		templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("/app/domains/" + c.UID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 205, Col: 50}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 208, Col: 50}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var37))
 		if templ_7745c5c3_Err != nil {
@@ -685,7 +685,7 @@ func DomainChildRow(c DomainRowView, apex string, last bool, csrfToken string, c
 		var templ_7745c5c3_Var38 string
 		templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.JoinStringErrs(childLabel(c.Name, apex))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 208, Col: 68}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 211, Col: 68}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var38))
 		if templ_7745c5c3_Err != nil {
@@ -698,7 +698,7 @@ func DomainChildRow(c DomainRowView, apex string, last bool, csrfToken string, c
 		var templ_7745c5c3_Var39 string
 		templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinStringErrs(apex)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 208, Col: 81}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 211, Col: 81}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var39))
 		if templ_7745c5c3_Err != nil {
@@ -711,7 +711,7 @@ func DomainChildRow(c DomainRowView, apex string, last bool, csrfToken string, c
 		var templ_7745c5c3_Var40 string
 		templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.JoinStringErrs(c.RecordCount)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 210, Col: 42}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 213, Col: 42}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var40))
 		if templ_7745c5c3_Err != nil {
@@ -752,7 +752,7 @@ func DomainChildRow(c DomainRowView, apex string, last bool, csrfToken string, c
 		var templ_7745c5c3_Var43 string
 		templ_7745c5c3_Var43, templ_7745c5c3_Err = templ.JoinStringErrs(c.FindingsLabel)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 216, Col: 22}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 219, Col: 22}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var43))
 		if templ_7745c5c3_Err != nil {
@@ -765,7 +765,7 @@ func DomainChildRow(c DomainRowView, apex string, last bool, csrfToken string, c
 		var templ_7745c5c3_Var44 string
 		templ_7745c5c3_Var44, templ_7745c5c3_Err = templ.JoinStringErrs(c.LastScan)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 219, Col: 39}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 222, Col: 39}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var44))
 		if templ_7745c5c3_Err != nil {
@@ -783,7 +783,7 @@ func DomainChildRow(c DomainRowView, apex string, last bool, csrfToken string, c
 			var templ_7745c5c3_Var45 string
 			templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.JoinStringErrs(deleteRowWithConfirm("/app/domains/"+c.UID, csrfToken))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 226, Col: 75}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 229, Col: 75}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var45))
 			if templ_7745c5c3_Err != nil {
@@ -946,7 +946,7 @@ func DomainRow(d DomainRowView, csrfToken string, canManage bool) templ.Componen
 		var templ_7745c5c3_Var53 string
 		templ_7745c5c3_Var53, templ_7745c5c3_Err = templ.JoinStringErrs("domain-row-" + d.UID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 258, Col: 28}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 261, Col: 28}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var53))
 		if templ_7745c5c3_Err != nil {
@@ -959,7 +959,7 @@ func DomainRow(d DomainRowView, csrfToken string, canManage bool) templ.Componen
 		var templ_7745c5c3_Var54 templ.SafeURL
 		templ_7745c5c3_Var54, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL("/app/domains/" + d.UID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 260, Col: 50}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 263, Col: 50}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var54))
 		if templ_7745c5c3_Err != nil {
@@ -972,7 +972,7 @@ func DomainRow(d DomainRowView, csrfToken string, canManage bool) templ.Componen
 		var templ_7745c5c3_Var55 string
 		templ_7745c5c3_Var55, templ_7745c5c3_Err = templ.JoinStringErrs(d.Name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 263, Col: 28}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 266, Col: 28}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var55))
 		if templ_7745c5c3_Err != nil {
@@ -985,7 +985,7 @@ func DomainRow(d DomainRowView, csrfToken string, canManage bool) templ.Componen
 		var templ_7745c5c3_Var56 string
 		templ_7745c5c3_Var56, templ_7745c5c3_Err = templ.JoinStringErrs(d.RecordCount)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 265, Col: 42}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 268, Col: 42}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var56))
 		if templ_7745c5c3_Err != nil {
@@ -1026,7 +1026,7 @@ func DomainRow(d DomainRowView, csrfToken string, canManage bool) templ.Componen
 		var templ_7745c5c3_Var59 string
 		templ_7745c5c3_Var59, templ_7745c5c3_Err = templ.JoinStringErrs(d.FindingsLabel)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 271, Col: 22}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 274, Col: 22}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var59))
 		if templ_7745c5c3_Err != nil {
@@ -1039,7 +1039,7 @@ func DomainRow(d DomainRowView, csrfToken string, canManage bool) templ.Componen
 		var templ_7745c5c3_Var60 string
 		templ_7745c5c3_Var60, templ_7745c5c3_Err = templ.JoinStringErrs(d.LastScan)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 274, Col: 39}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 277, Col: 39}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var60))
 		if templ_7745c5c3_Err != nil {
@@ -1057,7 +1057,7 @@ func DomainRow(d DomainRowView, csrfToken string, canManage bool) templ.Componen
 			var templ_7745c5c3_Var61 string
 			templ_7745c5c3_Var61, templ_7745c5c3_Err = templ.JoinStringErrs(deleteRowWithConfirm("/app/domains/"+d.UID, csrfToken))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 281, Col: 75}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/ui/templates/domains.templ`, Line: 284, Col: 75}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var61))
 			if templ_7745c5c3_Err != nil {

--- a/sql/queries/observations.sql
+++ b/sql/queries/observations.sql
@@ -5,6 +5,15 @@ INSERT INTO scans (tenant_id, domain_id, domain_uid, domain_name, parent_scan_id
 VALUES ($1, $2, $3, $4, $5, $6)
 RETURNING id, uid, tenant_id, domain_id, domain_uid, domain_name, parent_scan_id, source, started_at;
 
+-- name: NotifyDomainObservation :exec
+-- Fire a LISTEN/NOTIFY signal that an observation was written for a domain. The
+-- server process LISTENs on 'domain_observations' and fans the change out to
+-- browser SSE streams. Called on the observation transaction's connection, so
+-- the signal is delivered on COMMIT and dropped on ROLLBACK — subscribers never
+-- observe uncommitted state. Delivery is best-effort: a listener that is down
+-- when this fires misses the event (the DB stays source of truth).
+SELECT pg_notify('domain_observations', @payload::text);
+
 -- name: AcquireDomainScanLock :exec
 -- Transaction-scoped advisory lock keyed on domain_id. Serializes concurrent
 -- scan enqueues for the same domain so the recency-check-then-enqueue is atomic


### PR DESCRIPTION
## Summary

Push scan and lifecycle changes to open browser sessions without a reload. `serve` and `worker` run as separate processes, so the worker's observation writes reach the server's SSE connections over Postgres LISTEN/NOTIFY — transactional: delivered on COMMIT, dropped on ROLLBACK.

- `observer.Recorder` fires `pg_notify('domain_observations', ...)` when a real change is recorded; suppressed/unchanged writes notify nothing.
- `NotifyDomainLifecycle` covers create/update/delete, which write no observation but are still list-visible.
- `SSEBroker` fans tenant-scoped events to subscribers; a dedicated listener connection re-LISTENs on reconnect (best-effort, DB stays source of truth).
- `/app/domains/stream` coalesces a burst of events (an enumeration scan writes hundreds) into one inner-patch of `#domains-rows` per interval, reusing the create flow's render path so it never re-triggers the stream opener. `/app/domains/{uid}/stream` refreshes the detail panels.
- Long-lived streams clear the server read/write deadlines so the `http.Server` timeouts don't tear them down.