### PR TITLE
Make compose.yaml a no-profile prod default for single-file deploys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,5 @@ MAIL_DRIVER=log
 # MAIL_FROM=noreply@gecko.example.com
 
 # ── Compose ──
-COMPOSE_PROFILES=prod                  # makes `docker compose up -d` run the full stack
 # GECKO_IMAGE=ghcr.io/danielmichaels/gecko:v1.2.3   # pin a release instead of :latest
 # RIVERUI_PORT=8080                                 # host port (localhost) for riverui

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -50,7 +50,7 @@ tasks:
   compose:up:
     desc: Run local compose
     cmds:
-      - docker compose -f {{.DOCKER_COMPOSE_LOCAL}} --profile ${COMPOSE_PROFILE:-dev} up --wait -d
+      - docker compose -f {{.DOCKER_COMPOSE_LOCAL}} up --wait -d {{.DATABASE_CONTAINER_NAME}} riverui
       - docker compose -f {{.DOCKER_COMPOSE_LOCAL}} exec {{.DATABASE_CONTAINER_NAME}} /bin/sh -c 'until pg_isready; do sleep 1; done'
       - task: db:migration:up
       - task: river:migration:up

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,11 +1,10 @@
 name: gecko
 
-# One stack for dev and prod, split by Compose profiles:
-#   prod : db, riverui, migrate, serve, worker   (set COMPOSE_PROFILES=prod in .env →
-#          `docker compose up -d` runs the full stack)
-#   dev  : db, riverui, mailpit                  (`docker compose --profile dev up -d`;
-#          run serve/worker on the host via `task serve` / `task worker`)
-# db + riverui are unprofiled, so they run under either profile. See DEPLOY.md.
+# Single stack. A bare `docker compose up -d` runs the full prod stack
+# (db, riverui, migrate, serve, worker) — no profiles, so platforms like Dokploy
+# that issue a bare `up` get everything. mailpit is dev-only (profiles: [dev]).
+# Local dev runs the lean subset and serve/worker on the host — see Taskfile
+# `compose:up` (`docker compose up -d db riverui`; `task serve` / `task worker`). See DEPLOY.md.
 
 services:
   db:
@@ -38,19 +37,17 @@ services:
     depends_on:
       db: { condition: service_healthy }   # not serve, so this stays valid under the dev profile
 
-# uncomment for local smtp testing
-  #mailpit:                             # dev-only SMTP catcher
-  #  image: axllent/mailpit:latest
-  #  profiles: [dev]
-  #  restart: always
-  #  networks: [gecko]
-  #  ports:
-  #    - "127.0.0.1:8025:8025"          # web UI
-  #    - "127.0.0.1:1025:1025"          # SMTP
+  mailpit:                             # dev-only SMTP catcher; start with `docker compose up -d mailpit`
+    image: axllent/mailpit:latest
+    profiles: [dev]                    # never starts under a bare `up`; named explicitly in dev
+    restart: always
+    networks: [gecko]
+    ports:
+      - "127.0.0.1:8025:8025"          # web UI
+      - "127.0.0.1:1025:1025"          # SMTP
 
   migrate:
     image: ${GECKO_IMAGE:-ghcr.io/danielmichaels/gecko:latest}
-    profiles: [prod]
     command: [migrate]                 # goose schema migrations, then exits
     env_file: [.env]
     environment:                       # reach the bundled db on the compose network,
@@ -63,7 +60,6 @@ services:
 
   serve:
     image: ${GECKO_IMAGE:-ghcr.io/danielmichaels/gecko:latest}
-    profiles: [prod]
     command: [serve]                   # applies River migrations on startup
     env_file: [.env]
     environment:
@@ -85,7 +81,6 @@ services:
 
   worker:                              # needs UDP/53 + TCP/53 egress (DNS + AXFR)
     image: ${GECKO_IMAGE:-ghcr.io/danielmichaels/gecko:latest}
-    profiles: [prod]
     command: [worker]
     env_file: [.env]
     environment:


### PR DESCRIPTION
## Problem

Platforms like Dokploy deploy from a **single compose file** invoked with a bare `docker compose up -d`, and do **not** apply `COMPOSE_PROFILES`. The previous `compose.yaml` gated the actual app services — `migrate`, `serve`, `worker` — behind `profiles: [prod]`, leaving only the unprofiled `db` + `riverui` to start under a bare `up`.

Result: a staging deploy reported success while the application never started — only the two infra containers came up.

## Change

- Remove `profiles: [prod]` from `migrate`/`serve`/`worker` so a bare `docker compose up -d` runs the full prod stack with zero extra config.
- `mailpit` becomes the lone `profiles: [dev]` service (was commented out), so it stays out of a bare `up`.
- `task compose:up` now names its dev subset (`db riverui`) instead of selecting a profile; `serve`/`worker` still run on the host via `air` for local dev.
- Drop the now-dead `COMPOSE_PROFILES=prod` from `.env.example`.

`depends_on` ordering is unchanged: `db → migrate → serve → worker` (+ `riverui` off `db`).