### PR TITLE
feat(domains): filter domains list API by source and domain_type

### DIFF
--- a/internal/dto/domains.go
+++ b/internal/dto/domains.go
@@ -89,33 +89,10 @@ func DomainRecordsToAPI(records []store.DomainsGetAllRecordsByTenantIDRow) []Dom
 	return dtos
 }
 
-// DomainSearchByNameRowToDomains converts a slice of store.DomainsSearchByNameRow to a slice of store.Domains.
+// DomainsListRowToDomains converts a slice of store.DomainsListRow to a slice of store.Domains.
 // It iterates over the input slice and creates a new slice of store.Domains, populating the fields
 // from the corresponding fields in the input slice.
-func DomainSearchByNameRowToDomains(rows []store.DomainsSearchByNameRow) []store.Domains {
-	domains := make([]store.Domains, len(rows))
-	for i, row := range rows {
-		domains[i] = store.Domains{
-			ID:            row.ID,
-			Uid:           row.Uid,
-			TenantID:      row.TenantID,
-			Name:          row.Name,
-			DomainType:    row.DomainType,
-			Source:        row.Source,
-			Status:        row.Status,
-			LastScannedAt: row.LastScannedAt,
-			NextScanAt:    row.NextScanAt,
-			CreatedAt:     row.CreatedAt,
-			UpdatedAt:     row.UpdatedAt,
-		}
-	}
-	return domains
-}
-
-// DomainsListByTenantIDToDomains converts a slice of store.DomainsListByTenantIDRow to a slice of store.Domains.
-// It iterates over the input slice and creates a new slice of store.Domains, populating the fields
-// from the corresponding fields in the input slice.
-func DomainsListByTenantIDToDomains(rows []store.DomainsListByTenantIDRow) []store.Domains {
+func DomainsListRowToDomains(rows []store.DomainsListRow) []store.Domains {
 	domains := make([]store.Domains, len(rows))
 	for i, row := range rows {
 		domains[i] = store.Domains{

--- a/internal/server/domains_filter_test.go
+++ b/internal/server/domains_filter_test.go
@@ -1,0 +1,182 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/danielmichaels/gecko/internal/store"
+	"github.com/danielmichaels/gecko/internal/testhelpers"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+type domainListResp struct {
+	Pagination struct {
+		Total    int64 `json:"total_results"`
+		PageSize int32 `json:"page_size"`
+		Count    int32 `json:"count"`
+	} `json:"pagination"`
+	Domains []struct {
+		Domain     string `json:"domain"`
+		DomainType string `json:"domain_type"`
+		Source     string `json:"source"`
+	} `json:"domains"`
+}
+
+func seedDomainTyped(
+	t *testing.T,
+	ctx context.Context,
+	pc *testhelpers.PostgresContainer,
+	tenantID int32,
+	name string,
+	domainType store.DomainType,
+	source store.DomainSource,
+) store.DomainsInsertRow {
+	t.Helper()
+	d, err := pc.Queries.DomainsInsert(ctx, store.DomainsInsertParams{
+		TenantID:   pgtype.Int4{Int32: tenantID, Valid: true},
+		Name:       name,
+		DomainType: domainType,
+		Source:     source,
+		Status:     store.DomainStatusActive,
+	})
+	if err != nil {
+		t.Fatalf("seed domain %s: %v", name, err)
+	}
+	return d
+}
+
+// TestDomainsListFilterAPI exercises GET /api/domains source/domain_type filters
+// through the full chi → huma → apiAuth chain: each filter narrows the result,
+// pagination total reflects the FILTERED set, tenancy holds, and an unknown enum
+// value is rejected at the Huma boundary.
+func TestDomainsListFilterAPI(t *testing.T) {
+	testhelpers.ParallelDBTest(t)
+	ctx := context.Background()
+	pc, err := testhelpers.CreatePostgresContainer(ctx)
+	if err != nil {
+		t.Fatalf("create container: %v", err)
+	}
+	defer pc.Close(ctx)
+	_, base := newAuthAPI(t, pc)
+
+	a := signup(t, base, "owner@filter-a.com", "supersecret")
+	signup(t, base, "owner@filter-b.com", "supersecret")
+	tenantA := tenantIDByEmail(t, ctx, pc, "owner@filter-a.com")
+	tenantB := tenantIDByEmail(t, ctx, pc, "owner@filter-b.com")
+
+	seedDomainTyped(
+		t,
+		ctx,
+		pc,
+		tenantA,
+		"apex.example.com",
+		store.DomainTypeTld,
+		store.DomainSourceUserSupplied,
+	)
+	seedDomainTyped(
+		t,
+		ctx,
+		pc,
+		tenantA,
+		"sub.example.com",
+		store.DomainTypeSubdomain,
+		store.DomainSourceUserSupplied,
+	)
+	seedDomainTyped(
+		t,
+		ctx,
+		pc,
+		tenantA,
+		"found.example.com",
+		store.DomainTypeSubdomain,
+		store.DomainSourceDiscovered,
+	)
+	// Tenant B domain that would match A's filters if isolation were broken.
+	seedDomainTyped(
+		t,
+		ctx,
+		pc,
+		tenantB,
+		"b-apex.example.com",
+		store.DomainTypeTld,
+		store.DomainSourceUserSupplied,
+	)
+
+	t.Run("filter by source narrows result", func(t *testing.T) {
+		var res domainListResp
+		if code := doJSON(t, http.MethodGet, base+"/api/domains?source=discovered", a.APIKey, nil, &res); code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", code)
+		}
+		if res.Pagination.Total != 1 || len(res.Domains) != 1 {
+			t.Fatalf(
+				"discovered total/len = %d/%d, want 1/1",
+				res.Pagination.Total,
+				len(res.Domains),
+			)
+		}
+		if res.Domains[0].Domain != "found.example.com" || res.Domains[0].Source != "discovered" {
+			t.Errorf("discovered domain = %+v, want found.example.com/discovered", res.Domains[0])
+		}
+	})
+
+	t.Run("filter by domain_type narrows result", func(t *testing.T) {
+		var res domainListResp
+		if code := doJSON(t, http.MethodGet, base+"/api/domains?domain_type=tld", a.APIKey, nil, &res); code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", code)
+		}
+		if res.Pagination.Total != 1 || res.Domains[0].Domain != "apex.example.com" {
+			t.Errorf(
+				"tld total = %d, domain = %q, want 1 / apex.example.com",
+				res.Pagination.Total,
+				res.Domains[0].Domain,
+			)
+		}
+	})
+
+	t.Run("source and domain_type combine", func(t *testing.T) {
+		var res domainListResp
+		if code := doJSON(t, http.MethodGet, base+"/api/domains?source=user_supplied&domain_type=tld", a.APIKey, nil, &res); code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", code)
+		}
+		if res.Pagination.Total != 1 || res.Domains[0].Domain != "apex.example.com" {
+			t.Errorf(
+				"combined total = %d, domain = %q, want 1 / apex.example.com",
+				res.Pagination.Total,
+				res.Domains[0].Domain,
+			)
+		}
+	})
+
+	t.Run("total reflects filtered set under pagination", func(t *testing.T) {
+		var res domainListResp
+		if code := doJSON(t, http.MethodGet, base+"/api/domains?source=user_supplied&page_size=1", a.APIKey, nil, &res); code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", code)
+		}
+		// Two user_supplied domains in tenant A; page slices to one, total stays 2
+		// (the filtered total, not the tenant-wide 3).
+		if res.Pagination.Total != 2 || res.Pagination.Count != 1 {
+			t.Errorf(
+				"paginated total/count = %d/%d, want 2/1",
+				res.Pagination.Total,
+				res.Pagination.Count,
+			)
+		}
+	})
+
+	t.Run("no filter is tenant-scoped", func(t *testing.T) {
+		var res domainListResp
+		if code := doJSON(t, http.MethodGet, base+"/api/domains", a.APIKey, nil, &res); code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", code)
+		}
+		if res.Pagination.Total != 3 {
+			t.Errorf("unfiltered total = %d, want 3 (tenant A only)", res.Pagination.Total)
+		}
+	})
+
+	t.Run("unknown source value is rejected", func(t *testing.T) {
+		if code := doJSON(t, http.MethodGet, base+"/api/domains?source=bogus", a.APIKey, nil, nil); code != http.StatusUnprocessableEntity {
+			t.Errorf("bogus source status = %d, want 422", code)
+		}
+	})
+}

--- a/internal/server/domains_handlers.go
+++ b/internal/server/domains_handlers.go
@@ -34,7 +34,9 @@ type DomainBody struct {
 }
 
 func (app *Server) handleDomainList(ctx context.Context, i *struct {
-	FilterName string `query:"name" example:"example.com" doc:"Filter by domain name. Optional."`
+	FilterName string `query:"name"        example:"example.com"  doc:"Filter by domain name. Optional."`
+	Source     string `query:"source"      enum:"user_supplied,discovered"             example:"user_supplied" doc:"Filter by provenance: user_supplied (explicitly added) or discovered (found by enumeration). Optional."`
+	DomainType string `query:"domain_type" enum:"tld,subdomain,wildcard,old,other"     example:"tld"           doc:"Filter by domain structure. Optional."`
 	PaginationQuery
 },
 ) (*DomainListOutput, error) {
@@ -45,10 +47,15 @@ func (app *Server) handleDomainList(ctx context.Context, i *struct {
 	pageSize, pageNumber, offset := i.GetPaginationParams()
 	result, err := app.Svc.DomainsService().List(ctx, p, service.DomainsListParams{
 		FilterName: i.FilterName,
+		Source:     i.Source,
+		DomainType: i.DomainType,
 		PageSize:   pageSize,
 		Offset:     offset,
 	})
 	if err != nil {
+		if errors.Is(err, service.ErrInvalidInput) {
+			return nil, huma.Error400BadRequest(err.Error())
+		}
 		return nil, huma.Error500InternalServerError("failed to list domains", err)
 	}
 

--- a/internal/service/domains.go
+++ b/internal/service/domains.go
@@ -21,9 +21,13 @@ type DomainsService struct {
 	*Service
 }
 
-// DomainsListParams carries pagination and optional search filter for List.
+// DomainsListParams carries pagination and optional filters for List. Source and
+// DomainType are validated against the domain_source / domain_type enums: an empty
+// string means "no filter" and an unknown value yields ErrInvalidInput.
 type DomainsListParams struct {
 	FilterName string
+	Source     string
+	DomainType string
 	PageSize   int32
 	Offset     int32
 }
@@ -49,39 +53,36 @@ type DomainsUpdateParams struct {
 	Status     string
 }
 
-// List returns a tenant-scoped page of domains, optionally filtered by name.
-// The search branch wraps the filter with a LIKE wildcard.
+// List returns a tenant-scoped page of domains with optional name/source/
+// domain_type filters. Each filter is independently optional (NULL = no filter)
+// and resolved into one DomainsList query. An unknown source/domain_type value is
+// rejected with ErrInvalidInput before the query runs.
 func (s *DomainsService) List(
 	ctx context.Context,
 	p *auth.Principal,
 	params DomainsListParams,
 ) (DomainsListResult, error) {
-	tenantID := pgtype.Int4{Int32: p.TenantID, Valid: true}
-
-	if params.FilterName != "" {
-		rows, err := s.DB.DomainsSearchByName(ctx, store.DomainsSearchByNameParams{
-			TenantID: tenantID,
-			Name:     "%" + params.FilterName + "%",
-			Limit:    params.PageSize,
-			Offset:   params.Offset,
-		})
-		if err != nil {
-			return DomainsListResult{}, fmt.Errorf("domains search: %w", err)
-		}
-		var total int64
-		if len(rows) > 0 {
-			total = rows[0].TotalCount
-		}
-		return DomainsListResult{
-			Domains:    dto.DomainSearchByNameRowToDomains(rows),
-			TotalCount: total,
-		}, nil
+	source, err := toNullDomainSource(params.Source)
+	if err != nil {
+		return DomainsListResult{}, err
+	}
+	domainType, err := toNullDomainType(params.DomainType)
+	if err != nil {
+		return DomainsListResult{}, err
 	}
 
-	rows, err := s.DB.DomainsListByTenantID(ctx, store.DomainsListByTenantIDParams{
-		TenantID: tenantID,
-		Limit:    params.PageSize,
-		Offset:   params.Offset,
+	var name pgtype.Text
+	if params.FilterName != "" {
+		name = pgtype.Text{String: params.FilterName, Valid: true}
+	}
+
+	rows, err := s.DB.DomainsList(ctx, store.DomainsListParams{
+		TenantID:   pgtype.Int4{Int32: p.TenantID, Valid: true},
+		Name:       name,
+		Source:     source,
+		DomainType: domainType,
+		PageLimit:  params.PageSize,
+		PageOffset: params.Offset,
 	})
 	if err != nil {
 		return DomainsListResult{}, fmt.Errorf("domains list: %w", err)
@@ -91,9 +92,39 @@ func (s *DomainsService) List(
 		total = rows[0].TotalCount
 	}
 	return DomainsListResult{
-		Domains:    dto.DomainsListByTenantIDToDomains(rows),
+		Domains:    dto.DomainsListRowToDomains(rows),
 		TotalCount: total,
 	}, nil
+}
+
+// toNullDomainSource validates an optional source filter against the domain_source
+// enum: "" means no filter, a known value is applied, anything else is rejected
+// with ErrInvalidInput so a typo can't silently widen the result set.
+func toNullDomainSource(s string) (store.NullDomainSource, error) {
+	if s == "" {
+		return store.NullDomainSource{}, nil
+	}
+	switch store.DomainSource(s) {
+	case store.DomainSourceUserSupplied, store.DomainSourceDiscovered:
+		return store.NullDomainSource{DomainSource: store.DomainSource(s), Valid: true}, nil
+	default:
+		return store.NullDomainSource{}, fmt.Errorf("%w: source %q", ErrInvalidInput, s)
+	}
+}
+
+// toNullDomainType validates an optional domain_type filter against the domain_type
+// enum, with the same "" = no filter / unknown = ErrInvalidInput contract.
+func toNullDomainType(s string) (store.NullDomainType, error) {
+	if s == "" {
+		return store.NullDomainType{}, nil
+	}
+	switch store.DomainType(s) {
+	case store.DomainTypeTld, store.DomainTypeSubdomain, store.DomainTypeWildcard,
+		store.DomainTypeOld, store.DomainTypeOther:
+		return store.NullDomainType{DomainType: store.DomainType(s), Valid: true}, nil
+	default:
+		return store.NullDomainType{}, fmt.Errorf("%w: domain_type %q", ErrInvalidInput, s)
+	}
 }
 
 // DomainFindingSummary is the per-domain aggregate of open security findings,

--- a/internal/service/domains_test.go
+++ b/internal/service/domains_test.go
@@ -128,6 +128,31 @@ func seedDomain(
 	return d
 }
 
+// seedDomainWith inserts a domain with an explicit type and source, for the
+// list-filter tests that need provenance/structure variety.
+func seedDomainWith(
+	t *testing.T,
+	ctx context.Context,
+	pc *testhelpers.PostgresContainer,
+	tenantID int32,
+	name string,
+	domainType store.DomainType,
+	source store.DomainSource,
+) store.DomainsInsertRow {
+	t.Helper()
+	d, err := pc.Queries.DomainsInsert(ctx, store.DomainsInsertParams{
+		TenantID:   pgtype.Int4{Int32: tenantID, Valid: true},
+		Name:       name,
+		DomainType: domainType,
+		Source:     source,
+		Status:     store.DomainStatusActive,
+	})
+	if err != nil {
+		t.Fatalf("seed domain %s: %v", name, err)
+	}
+	return d
+}
+
 // createTenant inserts a tenant + owner user directly (mirroring signup) and returns the tenant ID.
 func createTenant(
 	t *testing.T,
@@ -221,6 +246,228 @@ func TestDomainsService_List_Search(t *testing.T) {
 	}
 	if result.Domains[0].Name != "alpha.example.com" {
 		t.Errorf("wrong domain: %s", result.Domains[0].Name)
+	}
+}
+
+func TestDomainsService_List_FilterBySource(t *testing.T) {
+	testhelpers.ParallelDBTest(t)
+	ctx := context.Background()
+	pc, err := testhelpers.CreatePostgresContainer(ctx)
+	if err != nil {
+		t.Fatalf("create container: %v", err)
+	}
+	defer pc.Close(ctx)
+
+	svc := newTestService(pc, &fakeScheduler{})
+	ds := svc.DomainsService()
+
+	tenantA := createTenant(t, ctx, pc, "a@source-filter.com")
+	tenantB := createTenant(t, ctx, pc, "b@source-filter.com")
+
+	seedDomainWith(
+		t,
+		ctx,
+		pc,
+		tenantA,
+		"apex.example.com",
+		store.DomainTypeTld,
+		store.DomainSourceUserSupplied,
+	)
+	seedDomainWith(
+		t,
+		ctx,
+		pc,
+		tenantA,
+		"sub.example.com",
+		store.DomainTypeSubdomain,
+		store.DomainSourceUserSupplied,
+	)
+	seedDomainWith(
+		t,
+		ctx,
+		pc,
+		tenantA,
+		"found.example.com",
+		store.DomainTypeSubdomain,
+		store.DomainSourceDiscovered,
+	)
+	// Another tenant's discovered domain must not leak into A's discovered filter.
+	seedDomainWith(
+		t,
+		ctx,
+		pc,
+		tenantB,
+		"b-found.example.com",
+		store.DomainTypeSubdomain,
+		store.DomainSourceDiscovered,
+	)
+
+	discovered, err := ds.List(ctx, ownerPrincipal(tenantA), service.DomainsListParams{
+		PageSize: 10,
+		Source:   string(store.DomainSourceDiscovered),
+	})
+	if err != nil {
+		t.Fatalf("List discovered: %v", err)
+	}
+	if discovered.TotalCount != 1 {
+		t.Errorf("discovered total = %d, want 1", discovered.TotalCount)
+	}
+	if len(discovered.Domains) == 1 && discovered.Domains[0].Name != "found.example.com" {
+		t.Errorf("discovered domain = %q, want found.example.com", discovered.Domains[0].Name)
+	}
+
+	userSupplied, err := ds.List(ctx, ownerPrincipal(tenantA), service.DomainsListParams{
+		PageSize: 10,
+		Source:   string(store.DomainSourceUserSupplied),
+	})
+	if err != nil {
+		t.Fatalf("List user_supplied: %v", err)
+	}
+	if userSupplied.TotalCount != 2 {
+		t.Errorf("user_supplied total = %d, want 2", userSupplied.TotalCount)
+	}
+}
+
+func TestDomainsService_List_FilterByType(t *testing.T) {
+	testhelpers.ParallelDBTest(t)
+	ctx := context.Background()
+	pc, err := testhelpers.CreatePostgresContainer(ctx)
+	if err != nil {
+		t.Fatalf("create container: %v", err)
+	}
+	defer pc.Close(ctx)
+
+	svc := newTestService(pc, &fakeScheduler{})
+	ds := svc.DomainsService()
+
+	tenantA := createTenant(t, ctx, pc, "a@type-filter.com")
+	seedDomainWith(
+		t,
+		ctx,
+		pc,
+		tenantA,
+		"apex.example.com",
+		store.DomainTypeTld,
+		store.DomainSourceUserSupplied,
+	)
+	seedDomainWith(
+		t,
+		ctx,
+		pc,
+		tenantA,
+		"sub.example.com",
+		store.DomainTypeSubdomain,
+		store.DomainSourceUserSupplied,
+	)
+	seedDomainWith(
+		t,
+		ctx,
+		pc,
+		tenantA,
+		"wild.example.com",
+		store.DomainTypeWildcard,
+		store.DomainSourceDiscovered,
+	)
+
+	tld, err := ds.List(ctx, ownerPrincipal(tenantA), service.DomainsListParams{
+		PageSize:   10,
+		DomainType: string(store.DomainTypeTld),
+	})
+	if err != nil {
+		t.Fatalf("List tld: %v", err)
+	}
+	if tld.TotalCount != 1 {
+		t.Errorf("tld total = %d, want 1", tld.TotalCount)
+	}
+	if len(tld.Domains) == 1 && tld.Domains[0].Name != "apex.example.com" {
+		t.Errorf("tld domain = %q, want apex.example.com", tld.Domains[0].Name)
+	}
+}
+
+func TestDomainsService_List_FilterBySourceAndType(t *testing.T) {
+	testhelpers.ParallelDBTest(t)
+	ctx := context.Background()
+	pc, err := testhelpers.CreatePostgresContainer(ctx)
+	if err != nil {
+		t.Fatalf("create container: %v", err)
+	}
+	defer pc.Close(ctx)
+
+	svc := newTestService(pc, &fakeScheduler{})
+	ds := svc.DomainsService()
+
+	tenantA := createTenant(t, ctx, pc, "a@both-filter.com")
+	// Two user_supplied tlds, but only one is the user_supplied+tld intersection
+	// we expect the combined filter to isolate.
+	seedDomainWith(
+		t,
+		ctx,
+		pc,
+		tenantA,
+		"apex.example.com",
+		store.DomainTypeTld,
+		store.DomainSourceUserSupplied,
+	)
+	seedDomainWith(
+		t,
+		ctx,
+		pc,
+		tenantA,
+		"discovered-apex.com",
+		store.DomainTypeTld,
+		store.DomainSourceDiscovered,
+	)
+	seedDomainWith(
+		t,
+		ctx,
+		pc,
+		tenantA,
+		"sub.example.com",
+		store.DomainTypeSubdomain,
+		store.DomainSourceUserSupplied,
+	)
+
+	res, err := ds.List(ctx, ownerPrincipal(tenantA), service.DomainsListParams{
+		PageSize:   10,
+		Source:     string(store.DomainSourceUserSupplied),
+		DomainType: string(store.DomainTypeTld),
+	})
+	if err != nil {
+		t.Fatalf("List both: %v", err)
+	}
+	if res.TotalCount != 1 {
+		t.Errorf("user_supplied+tld total = %d, want 1", res.TotalCount)
+	}
+	if len(res.Domains) == 1 && res.Domains[0].Name != "apex.example.com" {
+		t.Errorf("combined filter domain = %q, want apex.example.com", res.Domains[0].Name)
+	}
+}
+
+func TestDomainsService_List_InvalidEnumReturnsInvalidInput(t *testing.T) {
+	testhelpers.ParallelDBTest(t)
+	ctx := context.Background()
+	pc, err := testhelpers.CreatePostgresContainer(ctx)
+	if err != nil {
+		t.Fatalf("create container: %v", err)
+	}
+	defer pc.Close(ctx)
+
+	svc := newTestService(pc, &fakeScheduler{})
+	ds := svc.DomainsService()
+	tenantA := createTenant(t, ctx, pc, "a@invalid-enum.com")
+
+	if _, err := ds.List(ctx, ownerPrincipal(tenantA), service.DomainsListParams{
+		PageSize: 10,
+		Source:   "bogus",
+	}); !errors.Is(err, service.ErrInvalidInput) {
+		t.Errorf("invalid source err = %v, want ErrInvalidInput", err)
+	}
+
+	if _, err := ds.List(ctx, ownerPrincipal(tenantA), service.DomainsListParams{
+		PageSize:   10,
+		DomainType: "bogus",
+	}); !errors.Is(err, service.ErrInvalidInput) {
+		t.Errorf("invalid domain_type err = %v, want ErrInvalidInput", err)
 	}
 }
 

--- a/internal/store/domains.sql.go
+++ b/internal/store/domains.sql.go
@@ -575,7 +575,7 @@ func (q *Queries) DomainsInsert(ctx context.Context, arg DomainsInsertParams) (D
 	return i, err
 }
 
-const domainsListByTenantID = `-- name: DomainsListByTenantID :many
+const domainsList = `-- name: DomainsList :many
 SELECT id,
        uid,
        tenant_id,
@@ -590,17 +590,23 @@ SELECT id,
        count(*) OVER () AS total_count
 FROM domains
 WHERE tenant_id = $1
+  AND ($2::text IS NULL OR name ILIKE '%' || $2 || '%')
+  AND ($3::domain_source IS NULL OR source = $3)
+  AND ($4::domain_type IS NULL OR domain_type = $4)
 ORDER BY created_at DESC
-LIMIT $2 OFFSET $3
+LIMIT $6 OFFSET $5
 `
 
-type DomainsListByTenantIDParams struct {
-	TenantID pgtype.Int4 `json:"tenant_id"`
-	Limit    int32       `json:"limit"`
-	Offset   int32       `json:"offset"`
+type DomainsListParams struct {
+	TenantID   pgtype.Int4      `json:"tenant_id"`
+	Name       pgtype.Text      `json:"name"`
+	Source     NullDomainSource `json:"source"`
+	DomainType NullDomainType   `json:"domain_type"`
+	PageOffset int32            `json:"page_offset"`
+	PageLimit  int32            `json:"page_limit"`
 }
 
-type DomainsListByTenantIDRow struct {
+type DomainsListRow struct {
 	ID            int32              `json:"id"`
 	Uid           string             `json:"uid"`
 	TenantID      pgtype.Int4        `json:"tenant_id"`
@@ -615,16 +621,29 @@ type DomainsListByTenantIDRow struct {
 	TotalCount    int64              `json:"total_count"`
 }
 
-// List all domains for a tenant with pagination (no auth)
-func (q *Queries) DomainsListByTenantID(ctx context.Context, arg DomainsListByTenantIDParams) ([]DomainsListByTenantIDRow, error) {
-	rows, err := q.db.Query(ctx, domainsListByTenantID, arg.TenantID, arg.Limit, arg.Offset)
+// Tenant-scoped page of domains with optional name/source/domain_type filters.
+// Each filter is independently optional via narg (NULL = "no filter"), collapsing
+// the former DomainsListByTenantID + DomainsSearchByName into one query. tenant_id
+// stays the leading predicate so the multi-tenancy boundary is preserved; the
+// source/type equality filters are sargable (idx_domains_source/idx_domains_type)
+// and strictly cheaper than the non-sargable leading-wildcard name ILIKE.
+// total_count is the window count over the FILTERED set, for pagination.
+func (q *Queries) DomainsList(ctx context.Context, arg DomainsListParams) ([]DomainsListRow, error) {
+	rows, err := q.db.Query(ctx, domainsList,
+		arg.TenantID,
+		arg.Name,
+		arg.Source,
+		arg.DomainType,
+		arg.PageOffset,
+		arg.PageLimit,
+	)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []DomainsListByTenantIDRow{}
+	items := []DomainsListRow{}
 	for rows.Next() {
-		var i DomainsListByTenantIDRow
+		var i DomainsListRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.Uid,
@@ -762,86 +781,6 @@ type DomainsRecomputeNextScanByTenantDefaultParams struct {
 func (q *Queries) DomainsRecomputeNextScanByTenantDefault(ctx context.Context, arg DomainsRecomputeNextScanByTenantDefaultParams) error {
 	_, err := q.db.Exec(ctx, domainsRecomputeNextScanByTenantDefault, arg.IsOff, arg.BaseSecs, arg.TenantID)
 	return err
-}
-
-const domainsSearchByName = `-- name: DomainsSearchByName :many
-SELECT id,
-       uid,
-       tenant_id,
-       name,
-       domain_type,
-       source,
-       status,
-       last_scanned_at,
-       next_scan_at,
-       created_at,
-       updated_at,
-       count(*) OVER () AS total_count
-FROM domains
-WHERE tenant_id = $1
-  AND name ILIKE $2
-ORDER BY created_at DESC
-LIMIT $3 OFFSET $4
-`
-
-type DomainsSearchByNameParams struct {
-	TenantID pgtype.Int4 `json:"tenant_id"`
-	Name     string      `json:"name"`
-	Limit    int32       `json:"limit"`
-	Offset   int32       `json:"offset"`
-}
-
-type DomainsSearchByNameRow struct {
-	ID            int32              `json:"id"`
-	Uid           string             `json:"uid"`
-	TenantID      pgtype.Int4        `json:"tenant_id"`
-	Name          string             `json:"name"`
-	DomainType    DomainType         `json:"domain_type"`
-	Source        DomainSource       `json:"source"`
-	Status        DomainStatus       `json:"status"`
-	LastScannedAt pgtype.Timestamptz `json:"last_scanned_at"`
-	NextScanAt    pgtype.Timestamptz `json:"next_scan_at"`
-	CreatedAt     pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt     pgtype.Timestamptz `json:"updated_at"`
-	TotalCount    int64              `json:"total_count"`
-}
-
-func (q *Queries) DomainsSearchByName(ctx context.Context, arg DomainsSearchByNameParams) ([]DomainsSearchByNameRow, error) {
-	rows, err := q.db.Query(ctx, domainsSearchByName,
-		arg.TenantID,
-		arg.Name,
-		arg.Limit,
-		arg.Offset,
-	)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []DomainsSearchByNameRow{}
-	for rows.Next() {
-		var i DomainsSearchByNameRow
-		if err := rows.Scan(
-			&i.ID,
-			&i.Uid,
-			&i.TenantID,
-			&i.Name,
-			&i.DomainType,
-			&i.Source,
-			&i.Status,
-			&i.LastScannedAt,
-			&i.NextScanAt,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.TotalCount,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
 }
 
 const domainsSetScanFrequency = `-- name: DomainsSetScanFrequency :one

--- a/sql/queries/domains.sql
+++ b/sql/queries/domains.sql
@@ -158,8 +158,14 @@ SELECT id
 FROM domains
 WHERE tenant_id = $1;
 
--- name: DomainsListByTenantID :many
--- List all domains for a tenant with pagination (no auth)
+-- name: DomainsList :many
+-- Tenant-scoped page of domains with optional name/source/domain_type filters.
+-- Each filter is independently optional via narg (NULL = "no filter"), collapsing
+-- the former DomainsListByTenantID + DomainsSearchByName into one query. tenant_id
+-- stays the leading predicate so the multi-tenancy boundary is preserved; the
+-- source/type equality filters are sargable (idx_domains_source/idx_domains_type)
+-- and strictly cheaper than the non-sargable leading-wildcard name ILIKE.
+-- total_count is the window count over the FILTERED set, for pagination.
 SELECT id,
        uid,
        tenant_id,
@@ -173,28 +179,12 @@ SELECT id,
        updated_at,
        count(*) OVER () AS total_count
 FROM domains
-WHERE tenant_id = $1
+WHERE tenant_id = sqlc.arg(tenant_id)
+  AND (sqlc.narg(name)::text IS NULL OR name ILIKE '%' || sqlc.narg(name) || '%')
+  AND (sqlc.narg(source)::domain_source IS NULL OR source = sqlc.narg(source))
+  AND (sqlc.narg(domain_type)::domain_type IS NULL OR domain_type = sqlc.narg(domain_type))
 ORDER BY created_at DESC
-LIMIT $2 OFFSET $3;
-
--- name: DomainsSearchByName :many
-SELECT id,
-       uid,
-       tenant_id,
-       name,
-       domain_type,
-       source,
-       status,
-       last_scanned_at,
-       next_scan_at,
-       created_at,
-       updated_at,
-       count(*) OVER () AS total_count
-FROM domains
-WHERE tenant_id = $1
-  AND name ILIKE $2
-ORDER BY created_at DESC
-LIMIT $3 OFFSET $4;
+LIMIT sqlc.arg(page_limit) OFFSET sqlc.arg(page_offset);
 
 -- name: DomainsDeleteCount :one
 WITH RECURSIVE domain_tree AS (


### PR DESCRIPTION
Closes #53.

## Summary

Adds `source` and `domain_type` filters to `GET /api/domains`, alongside the existing `name` filter.

- **One dynamic query.** `DomainsListByTenantID` + `DomainsSearchByName` collapse into a single `DomainsList` query where `name`, `source`, and `domain_type` are each independently optional via sqlc `narg` (`NULL` = no filter). `tenant_id` stays the leading predicate, so tenant isolation is unchanged, and the `count(*) OVER ()` window reflects the **filtered** set for correct pagination totals.
- **Service validation.** `DomainsListParams` gains `Source`/`DomainType`; `List` validates both against the `domain_source` / `domain_type` enums and returns `ErrInvalidInput` on an unknown value, so a typo can't silently widen the result set.
- **API surface.** `source` and `domain_type` are Huma `enum` query params — the valid values are published in the OpenAPI spec and bad input is rejected with 422 at the edge (`ErrInvalidInput` also mapped to 400 as defense-in-depth for non-Huma callers).

## API

```
GET /api/domains?source=user_supplied
GET /api/domains?domain_type=tld
GET /api/domains?source=user_supplied&domain_type=tld&name=example
```

## Performance

Cheap: every filter is scoped under `tenant_id = $1`, and the `source`/`type` equality predicates are sargable (existing `idx_domains_source` / `idx_domains_type`) — strictly cheaper than the existing non-sargable leading-wildcard `name ILIKE`. No new index needed at current scale.

## Not included

The optional browser-UI `source` filter follow-on from the issue is left for a separate change.