### PR TITLE
feat(assessor): CAA configuration & compliance assessor (#62)

### DIFF
--- a/assets/migrations/00024_caa_findings_unique.sql
+++ b/assets/migrations/00024_caa_findings_unique.sql
@@ -1,0 +1,23 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE caa_configuration_findings
+    ADD CONSTRAINT caa_configuration_findings_domain_id_issue_type_key
+        UNIQUE (domain_id, issue_type);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE caa_compliance_findings
+    ADD CONSTRAINT caa_compliance_findings_domain_id_issue_type_key
+        UNIQUE (domain_id, issue_type);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE caa_configuration_findings
+    DROP CONSTRAINT caa_configuration_findings_domain_id_issue_type_key;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE caa_compliance_findings
+    DROP CONSTRAINT caa_compliance_findings_domain_id_issue_type_key;
+-- +goose StatementEnd

--- a/internal/assessor/assess_caa.go
+++ b/internal/assessor/assess_caa.go
@@ -1,0 +1,327 @@
+package assessor
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/danielmichaels/gecko/internal/observer"
+	"github.com/danielmichaels/gecko/internal/store"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+const (
+	CAAMissing             = "caa_missing"
+	CAAAllowsAnyCA         = "caa_allows_any_ca"
+	CAAUntrustedIssuer     = "caa_untrusted_issuer"
+	CAAUnknownCriticalFlag = "caa_unknown_critical_flag"
+	CAAConflictingRecords  = "caa_conflicting_records"
+	CAARequiredForCert     = "caa_required_for_cert"
+	CAAMissingIodef        = "missing_iodef"
+)
+
+const (
+	caaStandardName = "CAA RFC 8659"
+	caaCriticalFlag = 128
+)
+
+// defaultTrustedCAs is the built-in allowlist of CAA issuer identifiers (the
+// domain published in an `issue`/`issuewild` property) for well-known public
+// CAs. An `issue` value outside this set is surfaced as a low-severity finding
+// for human review; the list will drift over time and needs occasional upkeep.
+var defaultTrustedCAs = map[string]struct{}{
+	"letsencrypt.org": {},
+	"digicert.com":    {},
+	"sectigo.com":     {},
+	"comodoca.com":    {},
+	"globalsign.com":  {},
+	"google.com":      {},
+	"pki.goog":        {},
+	"amazon.com":      {},
+	"amazonaws.com":   {},
+	"amazontrust.com": {},
+	"awstrust.com":    {},
+	"godaddy.com":     {},
+	"ssl.com":         {},
+	"entrust.net":     {},
+	"buypass.com":     {},
+	"actalis.it":      {},
+	"certainly.com":   {},
+	"microsoft.com":   {},
+}
+
+// AssessCAA interprets the already-collected CAA records for a domain and
+// records configuration-quality findings (missing/unrestricted/untrusted
+// issuance, unknown critical flags, conflicting policy) plus standards
+// compliance findings (CAA required for cert-bearing domains, missing iodef).
+// It reads structured records from caa_records; no DNS egress occurs here.
+func (a *Assessor) AssessCAA(ctx context.Context, domainUID string) error {
+	domain, err := a.store.DomainsGetByIdentifier(ctx, store.DomainsGetByIdentifierParams{
+		Uid:      domainUID,
+		TenantID: pgtype.Int4{Int32: a.identity.TenantID, Valid: true},
+	})
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("domain %s not found in database", domainUID)
+		}
+		a.logger.ErrorContext(ctx, "Error looking up domain", "domain", domainUID, "error", err)
+		return err
+	}
+
+	records, err := a.store.RecordsGetCAAByDomainID(ctx, pgtype.Int4{Int32: domain.ID, Valid: true})
+	if err != nil {
+		a.logger.ErrorContext(
+			ctx,
+			"Failed to retrieve CAA records",
+			"domain",
+			domain.Uid,
+			"error",
+			err,
+		)
+		return err
+	}
+
+	hasCert := a.domainHasCertificate(ctx, domain.ID)
+	if len(records) == 0 {
+		return a.assessMissingCAA(ctx, domain.ID, hasCert)
+	}
+	return a.assessPresentCAA(ctx, domain.ID, hasCert, records)
+}
+
+func (a *Assessor) domainHasCertificate(ctx context.Context, domainID int32) bool {
+	_, err := a.store.ScannersGetCertificate(ctx, pgtype.Int4{Int32: domainID, Valid: true})
+	if err == nil {
+		return true
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		a.logger.WarnContext(ctx, "failed to check certificate presence for CAA assessment",
+			"domain_id", domainID, "error", err)
+	}
+	return false
+}
+
+func (a *Assessor) assessMissingCAA(ctx context.Context, domainID int32, hasCert bool) error {
+	severity := store.FindingSeverityInfo
+	if hasCert {
+		severity = store.FindingSeverityLow
+	}
+	if err := a.createCAAConfigFinding(ctx, domainID, severity, store.FindingStatusOpen,
+		CAAMissing, "No CAA records are published at the domain apex"); err != nil {
+		return err
+	}
+	if hasCert {
+		return a.createCAAComplianceFinding(ctx, domainID,
+			store.FindingSeverityLow, store.FindingStatusOpen, CAARequiredForCert,
+			"Domain serves a certificate but publishes no CAA policy restricting issuance")
+	}
+	return nil
+}
+
+func (a *Assessor) assessPresentCAA(
+	ctx context.Context,
+	domainID int32,
+	hasCert bool,
+	records []store.CaaRecords,
+) error {
+	var (
+		hasIssueTag        bool
+		hasIodef           bool
+		hasUnknownCritical bool
+		hasNoIssuance      bool
+		hasPermissiveIssue bool
+		sawIssuer          bool
+		untrusted          []string
+	)
+	for _, r := range records {
+		switch strings.ToLower(strings.TrimSpace(r.Tag)) {
+		case "issue", "issuewild":
+			isIssue := strings.EqualFold(strings.TrimSpace(r.Tag), "issue")
+			if isIssue {
+				hasIssueTag = true
+			}
+			ca := caaIssuerDomain(r.Value)
+			if ca == "" {
+				if isIssue {
+					hasNoIssuance = true
+				}
+				continue
+			}
+			sawIssuer = true
+			if isIssue {
+				hasPermissiveIssue = true
+			}
+			if !isTrustedCA(ca) {
+				untrusted = append(untrusted, ca)
+			}
+		case "iodef":
+			hasIodef = true
+		default:
+			if r.Flags&caaCriticalFlag != 0 {
+				hasUnknownCritical = true
+			}
+		}
+	}
+
+	missingSeverity := store.FindingSeverityInfo
+	if hasCert {
+		missingSeverity = store.FindingSeverityLow
+	}
+	if err := a.createCAAConfigFinding(ctx, domainID, missingSeverity, store.FindingStatusResolved,
+		CAAMissing, "CAA records are published at the domain apex"); err != nil {
+		return err
+	}
+
+	anyCAStatus := store.FindingStatusResolved
+	anyCADetails := "CAA records restrict certificate issuance to listed CAs"
+	if !hasIssueTag {
+		anyCAStatus = store.FindingStatusOpen
+		anyCADetails = "CAA records exist but contain no issue property, so any CA may issue certificates"
+	}
+	if err := a.createCAAConfigFinding(ctx, domainID, store.FindingSeverityLow, anyCAStatus,
+		CAAAllowsAnyCA, anyCADetails); err != nil {
+		return err
+	}
+
+	if sawIssuer {
+		issuerStatus := store.FindingStatusResolved
+		issuerDetails := "All authorised CAs are well-known public issuers"
+		if len(untrusted) > 0 {
+			issuerStatus = store.FindingStatusOpen
+			issuerDetails = fmt.Sprintf(
+				"CAA authorises issuance by unrecognised CA(s): %s",
+				strings.Join(untrusted, ", "),
+			)
+		}
+		if err := a.createCAAConfigFinding(ctx, domainID, store.FindingSeverityLow, issuerStatus,
+			CAAUntrustedIssuer, issuerDetails); err != nil {
+			return err
+		}
+	}
+
+	criticalStatus := store.FindingStatusResolved
+	criticalDetails := "No unrecognised CAA properties carry the critical flag"
+	if hasUnknownCritical {
+		criticalStatus = store.FindingStatusOpen
+		criticalDetails = "A CAA property gecko does not recognise has the critical flag set; conformant CAs must refuse issuance"
+	}
+	if err := a.createCAAConfigFinding(ctx, domainID, store.FindingSeverityMedium, criticalStatus,
+		CAAUnknownCriticalFlag, criticalDetails); err != nil {
+		return err
+	}
+
+	conflictStatus := store.FindingStatusResolved
+	conflictDetails := "CAA issuance policy is internally consistent"
+	if hasNoIssuance && hasPermissiveIssue {
+		conflictStatus = store.FindingStatusOpen
+		conflictDetails = "CAA contains a no-issuance directive (issue \";\") alongside a permissive issue property"
+	}
+	if err := a.createCAAConfigFinding(ctx, domainID, store.FindingSeverityMedium, conflictStatus,
+		CAAConflictingRecords, conflictDetails); err != nil {
+		return err
+	}
+
+	if hasCert {
+		if err := a.createCAAComplianceFinding(ctx, domainID,
+			store.FindingSeverityLow, store.FindingStatusResolved, CAARequiredForCert,
+			"Cert-bearing domain publishes a CAA policy"); err != nil {
+			return err
+		}
+	}
+
+	iodefStatus := store.FindingStatusResolved
+	iodefDetails := "CAA publishes an iodef reporting endpoint"
+	if !hasIodef {
+		iodefStatus = store.FindingStatusOpen
+		iodefDetails = "CAA does not publish an iodef property for violation reporting"
+	}
+	return a.createCAAComplianceFinding(ctx, domainID, store.FindingSeverityInfo, iodefStatus,
+		CAAMissingIodef, iodefDetails)
+}
+
+// caaIssuerDomain extracts the CA identifier from an issue/issuewild value,
+// dropping any parameters after the first semicolon. An empty result denotes a
+// no-issuance directive (e.g. `issue ";"`).
+func caaIssuerDomain(value string) string {
+	v := value
+	if i := strings.Index(v, ";"); i >= 0 {
+		v = v[:i]
+	}
+	return strings.ToLower(strings.Trim(strings.TrimSpace(v), "\""))
+}
+
+func isTrustedCA(ca string) bool {
+	_, ok := defaultTrustedCAs[ca]
+	return ok
+}
+
+func (a *Assessor) createCAAConfigFinding(
+	ctx context.Context,
+	domainID int32,
+	severity store.FindingSeverity,
+	status store.FindingStatus,
+	issueType, details string,
+) error {
+	if _, err := a.store.AssessCreateCAAConfigurationFinding(ctx, store.AssessCreateCAAConfigurationFindingParams{
+		DomainID:  pgtype.Int4{Int32: domainID, Valid: true},
+		Severity:  severity,
+		Status:    status,
+		IssueType: issueType,
+		Details:   pgtype.Text{String: details, Valid: details != ""},
+	}); err != nil {
+		a.logger.WarnContext(ctx, "failed to create caa configuration finding",
+			"issue_type", issueType, "error", err)
+		return fmt.Errorf("create caa configuration finding %s: %w", issueType, err)
+	}
+
+	payload := observer.PayloadJSON(map[string]any{
+		"issue_type": issueType,
+		"severity":   string(severity),
+		"status":     string(status),
+		"details":    details,
+	})
+	if oErr := observer.New(a.store).RecordFindingChange(
+		ctx, a.identity, observer.EntityCAAConfigurationFinding, issueType, payload,
+	); oErr != nil {
+		a.logger.WarnContext(ctx, "failed to emit caa configuration finding observation",
+			"issue_type", issueType, "error", oErr)
+	}
+	return nil
+}
+
+func (a *Assessor) createCAAComplianceFinding(
+	ctx context.Context,
+	domainID int32,
+	severity store.FindingSeverity,
+	status store.FindingStatus,
+	issueType, details string,
+) error {
+	if _, err := a.store.AssessCreateCAAComplianceFinding(ctx, store.AssessCreateCAAComplianceFindingParams{
+		DomainID:     pgtype.Int4{Int32: domainID, Valid: true},
+		Severity:     severity,
+		Status:       status,
+		IssueType:    issueType,
+		StandardName: pgtype.Text{String: caaStandardName, Valid: true},
+		Details:      pgtype.Text{String: details, Valid: details != ""},
+	}); err != nil {
+		a.logger.WarnContext(ctx, "failed to create caa compliance finding",
+			"issue_type", issueType, "error", err)
+		return fmt.Errorf("create caa compliance finding %s: %w", issueType, err)
+	}
+
+	payload := observer.PayloadJSON(map[string]any{
+		"issue_type":    issueType,
+		"severity":      string(severity),
+		"status":        string(status),
+		"standard_name": caaStandardName,
+		"details":       details,
+	})
+	if oErr := observer.New(a.store).RecordFindingChange(
+		ctx, a.identity, observer.EntityCAAComplianceFinding, issueType, payload,
+	); oErr != nil {
+		a.logger.WarnContext(ctx, "failed to emit caa compliance finding observation",
+			"issue_type", issueType, "error", oErr)
+	}
+	return nil
+}

--- a/internal/assessor/assess_caa_test.go
+++ b/internal/assessor/assess_caa_test.go
@@ -1,0 +1,297 @@
+package assessor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/danielmichaels/gecko/internal/observer"
+	"github.com/danielmichaels/gecko/internal/store"
+	"github.com/danielmichaels/gecko/internal/testhelpers"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+func caaConfigByIssueType(
+	findings []store.CaaConfigurationFindings,
+	issueType string,
+) (store.CaaConfigurationFindings, bool) {
+	for _, f := range findings {
+		if f.IssueType == issueType {
+			return f, true
+		}
+	}
+	return store.CaaConfigurationFindings{}, false
+}
+
+func caaComplianceByIssueType(
+	findings []store.CaaComplianceFindings,
+	issueType string,
+) (store.CaaComplianceFindings, bool) {
+	for _, f := range findings {
+		if f.IssueType == issueType {
+			return f, true
+		}
+	}
+	return store.CaaComplianceFindings{}, false
+}
+
+func TestAssessCAA(t *testing.T) {
+	ctx := context.Background()
+	pgContainer, err := testhelpers.CreatePostgresContainer(ctx)
+	if err != nil {
+		t.Fatalf("Failed to create postgres container: %v", err)
+	}
+	defer pgContainer.Close(ctx)
+
+	newDomain := func(t *testing.T, name string) store.DomainsCreateRow {
+		t.Helper()
+		d, err := pgContainer.Queries.DomainsCreate(ctx, store.DomainsCreateParams{
+			TenantID:   pgtype.Int4{Int32: 1, Valid: true},
+			Name:       name,
+			DomainType: store.DomainTypeTld,
+			Source:     store.DomainSourceUserSupplied,
+			Status:     store.DomainStatusActive,
+		})
+		if err != nil {
+			t.Fatalf("Failed to create domain %s: %v", name, err)
+		}
+		return d
+	}
+
+	seedCAA := func(t *testing.T, domainID int32, flags int32, tag, value string) {
+		t.Helper()
+		if _, err := pgContainer.Queries.RecordsCreateCAA(ctx, store.RecordsCreateCAAParams{
+			DomainID: pgtype.Int4{Int32: domainID, Valid: true},
+			Flags:    flags,
+			Tag:      tag,
+			Value:    value,
+		}); err != nil {
+			t.Fatalf("Failed to seed CAA record: %v", err)
+		}
+	}
+
+	seedCert := func(t *testing.T, domainID int32) {
+		t.Helper()
+		now := time.Now()
+		if _, err := pgContainer.Queries.ScannersStoreCertificate(ctx, store.ScannersStoreCertificateParams{
+			DomainID:      pgtype.Int4{Int32: domainID, Valid: true},
+			NotBefore:     pgtype.Timestamptz{Time: now.Add(-24 * time.Hour), Valid: true},
+			NotAfter:      pgtype.Timestamptz{Time: now.Add(60 * 24 * time.Hour), Valid: true},
+			Issuer:        "CN=R3,O=Let's Encrypt,C=US",
+			Subject:       "CN=example.test",
+			KeyAlgorithm:  "ECDSA",
+			KeyStrength:   256,
+			Sans:          []string{},
+			DnsNames:      []string{},
+			IssuerCertUrl: []string{},
+			CipherSuite:   "TLS_AES_128_GCM_SHA256",
+			TlsVersion:    "TLS 1.3",
+		}); err != nil {
+			t.Fatalf("Failed to seed certificate: %v", err)
+		}
+	}
+
+	run := func(t *testing.T, d store.DomainsCreateRow) {
+		t.Helper()
+		ident := observer.DomainIdentity{
+			TenantID:   1,
+			DomainID:   d.ID,
+			DomainUID:  d.Uid,
+			DomainName: d.Name,
+		}
+		a := NewAssessor(
+			Config{Store: pgContainer.Queries, Logger: testhelpers.TestLogger, Identity: ident},
+		)
+		if err := a.AssessCAA(ctx, d.Uid); err != nil {
+			t.Fatalf("AssessCAA failed: %v", err)
+		}
+	}
+
+	getConfig := func(t *testing.T, d store.DomainsCreateRow) []store.CaaConfigurationFindings {
+		t.Helper()
+		findings, err := pgContainer.Queries.AssessGetCAAConfigurationFindingsByDomainUID(
+			ctx,
+			store.AssessGetCAAConfigurationFindingsByDomainUIDParams{
+				Uid:      d.Uid,
+				TenantID: pgtype.Int4{Int32: 1, Valid: true},
+			},
+		)
+		if err != nil {
+			t.Fatalf("Failed to get CAA configuration findings: %v", err)
+		}
+		return findings
+	}
+
+	getCompliance := func(t *testing.T, d store.DomainsCreateRow) []store.CaaComplianceFindings {
+		t.Helper()
+		findings, err := pgContainer.Queries.AssessGetCAAComplianceFindingsByDomainUID(
+			ctx,
+			store.AssessGetCAAComplianceFindingsByDomainUIDParams{
+				Uid:      d.Uid,
+				TenantID: pgtype.Int4{Int32: 1, Valid: true},
+			},
+		)
+		if err != nil {
+			t.Fatalf("Failed to get CAA compliance findings: %v", err)
+		}
+		return findings
+	}
+
+	t.Run("no CAA and no cert is an informational missing finding", func(t *testing.T) {
+		d := newDomain(t, "no-caa-no-cert.test")
+		run(t, d)
+
+		f, ok := caaConfigByIssueType(getConfig(t, d), CAAMissing)
+		if !ok {
+			t.Fatalf("expected caa_missing finding")
+		}
+		if f.Severity != store.FindingSeverityInfo {
+			t.Errorf("expected info severity, got %s", f.Severity)
+		}
+		if f.Status != store.FindingStatusOpen {
+			t.Errorf("expected open status, got %s", f.Status)
+		}
+		if _, present := caaComplianceByIssueType(getCompliance(t, d), CAARequiredForCert); present {
+			t.Error("did not expect a cert-compliance finding without a certificate")
+		}
+	})
+
+	t.Run("no CAA with a certificate escalates and adds a compliance finding", func(t *testing.T) {
+		d := newDomain(t, "no-caa-with-cert.test")
+		seedCert(t, d.ID)
+		run(t, d)
+
+		cfg, ok := caaConfigByIssueType(getConfig(t, d), CAAMissing)
+		if !ok {
+			t.Fatalf("expected caa_missing finding")
+		}
+		if cfg.Severity != store.FindingSeverityLow {
+			t.Errorf("expected low severity when cert present, got %s", cfg.Severity)
+		}
+		if cfg.Status != store.FindingStatusOpen {
+			t.Errorf("expected open status, got %s", cfg.Status)
+		}
+
+		comp, ok := caaComplianceByIssueType(getCompliance(t, d), CAARequiredForCert)
+		if !ok {
+			t.Fatalf("expected caa_required_for_cert compliance finding")
+		}
+		if comp.Severity != store.FindingSeverityLow || comp.Status != store.FindingStatusOpen {
+			t.Errorf("expected low/open, got %s/%s", comp.Severity, comp.Status)
+		}
+		if !comp.StandardName.Valid || comp.StandardName.String == "" {
+			t.Error("expected standard_name to be set on the compliance finding")
+		}
+	})
+
+	t.Run("restrictive CAA with trusted issuer and iodef has no open findings", func(t *testing.T) {
+		d := newDomain(t, "good-caa.test")
+		seedCAA(t, d.ID, 0, "issue", "letsencrypt.org")
+		seedCAA(t, d.ID, 0, "iodef", "mailto:security@good-caa.test")
+		run(t, d)
+
+		for _, f := range getConfig(t, d) {
+			if f.Status == store.FindingStatusOpen {
+				t.Errorf("unexpected open config finding %s", f.IssueType)
+			}
+		}
+		for _, f := range getCompliance(t, d) {
+			if f.Status == store.FindingStatusOpen {
+				t.Errorf("unexpected open compliance finding %s", f.IssueType)
+			}
+		}
+		if missing, ok := caaConfigByIssueType(getConfig(t, d), CAAMissing); ok {
+			if missing.Status != store.FindingStatusResolved {
+				t.Errorf("expected caa_missing resolved, got %s", missing.Status)
+			}
+		}
+	})
+
+	t.Run("CAA without an issue tag permits any CA", func(t *testing.T) {
+		d := newDomain(t, "any-ca.test")
+		seedCAA(t, d.ID, 0, "iodef", "mailto:security@any-ca.test")
+		run(t, d)
+
+		f, ok := caaConfigByIssueType(getConfig(t, d), CAAAllowsAnyCA)
+		if !ok {
+			t.Fatalf("expected caa_allows_any_ca finding")
+		}
+		if f.Severity != store.FindingSeverityLow || f.Status != store.FindingStatusOpen {
+			t.Errorf("expected low/open, got %s/%s", f.Severity, f.Status)
+		}
+	})
+
+	t.Run("issuer outside the allowlist is flagged as untrusted", func(t *testing.T) {
+		d := newDomain(t, "untrusted-ca.test")
+		seedCAA(t, d.ID, 0, "issue", "sketchy-ca.example")
+		run(t, d)
+
+		f, ok := caaConfigByIssueType(getConfig(t, d), CAAUntrustedIssuer)
+		if !ok {
+			t.Fatalf("expected caa_untrusted_issuer finding")
+		}
+		if f.Severity != store.FindingSeverityLow || f.Status != store.FindingStatusOpen {
+			t.Errorf("expected low/open, got %s/%s", f.Severity, f.Status)
+		}
+	})
+
+	t.Run("critical flag on an unknown tag is a medium finding", func(t *testing.T) {
+		d := newDomain(t, "unknown-critical.test")
+		seedCAA(t, d.ID, 0, "issue", "letsencrypt.org")
+		seedCAA(t, d.ID, 128, "futuretag", "anything")
+		run(t, d)
+
+		f, ok := caaConfigByIssueType(getConfig(t, d), CAAUnknownCriticalFlag)
+		if !ok {
+			t.Fatalf("expected caa_unknown_critical_flag finding")
+		}
+		if f.Severity != store.FindingSeverityMedium || f.Status != store.FindingStatusOpen {
+			t.Errorf("expected medium/open, got %s/%s", f.Severity, f.Status)
+		}
+	})
+
+	t.Run("no-issuance directive alongside a permitted CA is conflicting", func(t *testing.T) {
+		d := newDomain(t, "conflicting-caa.test")
+		seedCAA(t, d.ID, 0, "issue", ";")
+		seedCAA(t, d.ID, 0, "issue", "letsencrypt.org")
+		run(t, d)
+
+		f, ok := caaConfigByIssueType(getConfig(t, d), CAAConflictingRecords)
+		if !ok {
+			t.Fatalf("expected caa_conflicting_records finding")
+		}
+		if f.Severity != store.FindingSeverityMedium || f.Status != store.FindingStatusOpen {
+			t.Errorf("expected medium/open, got %s/%s", f.Severity, f.Status)
+		}
+	})
+
+	t.Run("CAA without iodef is an informational compliance gap", func(t *testing.T) {
+		d := newDomain(t, "no-iodef.test")
+		seedCAA(t, d.ID, 0, "issue", "digicert.com")
+		run(t, d)
+
+		f, ok := caaComplianceByIssueType(getCompliance(t, d), CAAMissingIodef)
+		if !ok {
+			t.Fatalf("expected missing_iodef compliance finding")
+		}
+		if f.Severity != store.FindingSeverityInfo || f.Status != store.FindingStatusOpen {
+			t.Errorf("expected info/open, got %s/%s", f.Severity, f.Status)
+		}
+	})
+
+	t.Run("re-running does not duplicate findings", func(t *testing.T) {
+		d := newDomain(t, "idempotent-caa.test")
+		run(t, d)
+		run(t, d)
+
+		var count int
+		for _, f := range getConfig(t, d) {
+			if f.IssueType == CAAMissing {
+				count++
+			}
+		}
+		if count != 1 {
+			t.Errorf("expected exactly one caa_missing finding after re-run, got %d", count)
+		}
+	})
+}

--- a/internal/jobs/assess_jobs.go
+++ b/internal/jobs/assess_jobs.go
@@ -251,3 +251,50 @@ func (w *AssessDNSSECWorker) Work(
 	)
 	return nil
 }
+
+type AssessCAAArgs struct {
+	DomainJobArgs
+}
+
+func (AssessCAAArgs) InsertOpts() river.InsertOpts {
+	return river.InsertOpts{
+		Queue: queueAssessor,
+	}
+}
+func (AssessCAAArgs) Kind() string { return "assess_caa" }
+
+type AssessCAAWorker struct {
+	river.WorkerDefaults[AssessCAAArgs]
+	Logger   slog.Logger
+	Store    *store.Queries
+	PgxPool  *pgxpool.Pool
+	Resolver dnsclient.Resolver
+}
+
+func (w *AssessCAAWorker) Work(
+	ctx context.Context,
+	job *river.Job[AssessCAAArgs],
+) error {
+	ctx = tracing.WithNewTraceID(ctx, false)
+	start := time.Now()
+	w.Logger.InfoContext(ctx, "assess caa started", "domain", job.Args.DomainUID)
+	a := assessor.NewAssessor(assessor.Config{
+		Logger:    &w.Logger,
+		Store:     w.Store,
+		DNSClient: w.Resolver,
+		Identity:  job.Args.Identity(),
+	})
+	if err := a.AssessCAA(ctx, job.Args.DomainUID); err != nil {
+		return err
+	}
+
+	w.Logger.InfoContext(
+		ctx,
+		"assess caa complete",
+		"domain",
+		job.Args.DomainUID,
+		"duration",
+		time.Since(start),
+	)
+	return nil
+}

--- a/internal/jobs/enumerate_jobs.go
+++ b/internal/jobs/enumerate_jobs.go
@@ -239,6 +239,14 @@ func (w *ResolveDomainWorker) Work(ctx context.Context, job *river.Job[ResolveDo
 		return err
 	}
 
+	// CAA assessment runs unconditionally: a missing CAA record set is itself a
+	// finding, so it must be enqueued even when no CAA records were resolved.
+	if err := enqueueAssessment(ctx, w.PgxPool, &w.Logger, job.Args.DomainUID,
+		AssessCAAArgs{DomainJobArgs: job.Args.DomainJobArgs}); err != nil {
+		w.Logger.WarnContext(ctx, "failed to queue caa assessment",
+			"domain", job.Args.DomainUID, "error", err)
+	}
+
 	// Email security assessment is data-dependent: enqueue only when TXT records
 	// were discovered (SPF/DKIM/DMARC live in TXT).
 	if len(resolved.TXT.Entries) > 0 {

--- a/internal/jobs/river.go
+++ b/internal/jobs/river.go
@@ -171,6 +171,15 @@ func New(ctx context.Context, cfg Config) (*river.Client[pgx.Tx], error) {
 				Resolver: cfg.Resolver,
 			},
 		)
+		river.AddWorker(
+			rw,
+			&AssessCAAWorker{
+				Logger:   *cfg.Logger,
+				Store:    cfg.Store,
+				PgxPool:  cfg.PgxPool,
+				Resolver: cfg.Resolver,
+			},
+		)
 		// maintenance
 		river.AddWorker(rw, &PurgeDNSCacheWorker{Logger: *cfg.Logger, Store: cfg.Store})
 		river.AddWorker(rw, &RefreshTenantStatsWorker{Logger: *cfg.Logger, Store: cfg.Store})

--- a/internal/observer/recorder.go
+++ b/internal/observer/recorder.go
@@ -53,6 +53,9 @@ const (
 	EntityCNAMEDanglingFinding    = "dangling_cname_finding"
 	EntityCNAMERedirectionFinding = "cname_redirection_finding"
 
+	EntityCAAConfigurationFinding = "caa_configuration_finding"
+	EntityCAAComplianceFinding    = "caa_compliance_finding"
+
 	// EntityDomain is used only on lifecycle NOTIFY signals (create/delete/status),
 	// never stored as an observation — a domain's existence is the projection
 	// itself. It lets the UI refresh on changes that write no observation row.

--- a/internal/server/findings_handlers.go
+++ b/internal/server/findings_handlers.go
@@ -44,7 +44,7 @@ func toFindingItem(f service.FindingView) FindingItem {
 
 type FindingsListInput struct {
 	Severity         string `query:"severity"          example:"crit"  doc:"Filter by tier: crit|high|med|low. Optional." enum:"crit,high,med,low,"`
-	Kind             string `query:"kind"              example:"SPF"   doc:"Filter by type: SPF|DKIM|DMARC|ZONE|CERT|DNSSEC. Optional." enum:"SPF,DKIM,DMARC,ZONE,CERT,DNSSEC,"`
+	Kind             string `query:"kind"              example:"SPF"   doc:"Filter by type: SPF|DKIM|DMARC|ZONE|CERT|DNSSEC|CAA_CONFIG|CAA_COMPLIANCE. Optional." enum:"SPF,DKIM,DMARC,ZONE,CERT,DNSSEC,CAA_CONFIG,CAA_COMPLIANCE,"`
 	DomainQuery      string `query:"q"                 example:"acme"  doc:"Case-insensitive domain-name substring. Optional."`
 	IncludeCompliant bool   `query:"include_compliant" example:"false" doc:"Include compliant/closed findings. Optional."`
 	PaginationQuery

--- a/internal/service/findings.go
+++ b/internal/service/findings.go
@@ -171,6 +171,26 @@ func (s *FindingsService) ListByDomain(
 			))
 		}
 	}
+	if caaConfig, err := s.DB.AssessGetCAAConfigurationFindingsByDomainUID(ctx, store.AssessGetCAAConfigurationFindingsByDomainUIDParams{
+		Uid:      domainUID,
+		TenantID: tenantID,
+	}); err == nil {
+		for _, f := range caaConfig {
+			findings = append(findings, mapStandardFinding(
+				"CAA_CONFIG", f.Severity, f.Status, f.IssueType, f.Details,
+			))
+		}
+	}
+	if caaCompliance, err := s.DB.AssessGetCAAComplianceFindingsByDomainUID(ctx, store.AssessGetCAAComplianceFindingsByDomainUIDParams{
+		Uid:      domainUID,
+		TenantID: tenantID,
+	}); err == nil {
+		for _, f := range caaCompliance {
+			findings = append(findings, mapStandardFinding(
+				"CAA_COMPLIANCE", f.Severity, f.Status, f.IssueType, f.Details,
+			))
+		}
+	}
 
 	sort.SliceStable(findings, func(i, j int) bool {
 		return severityRank(findings[i].Severity) < severityRank(findings[j].Severity)
@@ -546,24 +566,31 @@ func findingTitle(issueType string) string {
 
 // findingTitles maps assessor issue_type values to human-readable card titles.
 var findingTitles = map[string]string{
-	"missing_spf":           "No SPF record published",
-	"weak_spf_policy":       "SPF policy too permissive (?all)",
-	"soft_fail_spf_policy":  "SPF uses soft-fail (~all)",
-	"missing_mechanisms":    "SPF specifies no senders",
-	"missing_all_mechanism": "SPF missing an 'all' mechanism",
-	"excessive_lookups":     "SPF exceeds the 10-lookup limit",
-	"spf_compliant":         "SPF correctly configured",
-	"missing_dkim":          "No DKIM records found",
-	"weak_key_length":       "DKIM key too weak",
-	"test_mode_enabled":     "DKIM in test mode",
-	"dkim_compliant":        "DKIM correctly configured",
-	"missing_dmarc":         "No DMARC policy published",
-	"weak_dmarc_policy":     "DMARC policy set to p=none",
-	"dmarc_missing_tags":    "DMARC missing rua/ruf tags",
-	"dmarc_compliant":       "DMARC correctly configured",
-	"not_applicable":        "Not applicable — domain doesn't handle email",
-	"zone_transfer_exposed": "Zone transfer (AXFR) exposed",
-	"zone_transfer_refused": "Zone transfer refused",
+	"missing_spf":               "No SPF record published",
+	"weak_spf_policy":           "SPF policy too permissive (?all)",
+	"soft_fail_spf_policy":      "SPF uses soft-fail (~all)",
+	"missing_mechanisms":        "SPF specifies no senders",
+	"missing_all_mechanism":     "SPF missing an 'all' mechanism",
+	"excessive_lookups":         "SPF exceeds the 10-lookup limit",
+	"spf_compliant":             "SPF correctly configured",
+	"missing_dkim":              "No DKIM records found",
+	"weak_key_length":           "DKIM key too weak",
+	"test_mode_enabled":         "DKIM in test mode",
+	"dkim_compliant":            "DKIM correctly configured",
+	"missing_dmarc":             "No DMARC policy published",
+	"weak_dmarc_policy":         "DMARC policy set to p=none",
+	"dmarc_missing_tags":        "DMARC missing rua/ruf tags",
+	"dmarc_compliant":           "DMARC correctly configured",
+	"not_applicable":            "Not applicable — domain doesn't handle email",
+	"zone_transfer_exposed":     "Zone transfer (AXFR) exposed",
+	"zone_transfer_refused":     "Zone transfer refused",
+	"caa_missing":               "No CAA records published",
+	"caa_allows_any_ca":         "CAA permits any CA to issue",
+	"caa_untrusted_issuer":      "CAA authorises an unrecognised CA",
+	"caa_unknown_critical_flag": "CAA has an unknown critical property",
+	"caa_conflicting_records":   "CAA issuance policy conflicts",
+	"caa_required_for_cert":     "Cert-bearing domain has no CAA",
+	"missing_iodef":             "CAA has no iodef reporting endpoint",
 }
 
 // findingDescriptions holds static descriptions for findings whose body text is
@@ -577,16 +604,23 @@ var findingDescriptions = map[string]string{
 // findingFixes maps issue_type values to a short remediation hint. Issue types
 // with no entry render without a fix line.
 var findingFixes = map[string]string{
-	"missing_spf":           "Publish an SPF record, e.g. v=spf1 include:_spf.provider.net -all",
-	"soft_fail_spf_policy":  "Tighten ~all to -all once all senders are enumerated.",
-	"weak_spf_policy":       "Replace ?all with -all (or ~all) to enforce the policy.",
-	"missing_all_mechanism": "End the SPF record with -all (or ~all).",
-	"excessive_lookups":     "Flatten includes to stay within the 10 DNS-lookup limit.",
-	"missing_dmarc":         "Publish v=DMARC1; p=none; rua=… then ramp to quarantine/reject.",
-	"weak_dmarc_policy":     "Move the DMARC policy from p=none to p=quarantine or p=reject.",
-	"dmarc_missing_tags":    "Add an rua= (and optionally ruf=) reporting address.",
-	"missing_dkim":          "Publish a DKIM key for your sending selector(s).",
-	"weak_key_length":       "Re-issue the DKIM key at 2048 bits.",
-	"test_mode_enabled":     "Remove t=y from the DKIM record once verified.",
-	"zone_transfer_exposed": "Restrict AXFR/IXFR to authorised secondary nameservers only.",
+	"missing_spf":               "Publish an SPF record, e.g. v=spf1 include:_spf.provider.net -all",
+	"soft_fail_spf_policy":      "Tighten ~all to -all once all senders are enumerated.",
+	"weak_spf_policy":           "Replace ?all with -all (or ~all) to enforce the policy.",
+	"missing_all_mechanism":     "End the SPF record with -all (or ~all).",
+	"excessive_lookups":         "Flatten includes to stay within the 10 DNS-lookup limit.",
+	"missing_dmarc":             "Publish v=DMARC1; p=none; rua=… then ramp to quarantine/reject.",
+	"weak_dmarc_policy":         "Move the DMARC policy from p=none to p=quarantine or p=reject.",
+	"dmarc_missing_tags":        "Add an rua= (and optionally ruf=) reporting address.",
+	"missing_dkim":              "Publish a DKIM key for your sending selector(s).",
+	"weak_key_length":           "Re-issue the DKIM key at 2048 bits.",
+	"test_mode_enabled":         "Remove t=y from the DKIM record once verified.",
+	"zone_transfer_exposed":     "Restrict AXFR/IXFR to authorised secondary nameservers only.",
+	"caa_missing":               "Publish a CAA record, e.g. example.com. IN CAA 0 issue \"letsencrypt.org\"",
+	"caa_required_for_cert":     "Add a CAA record authorising the CA that issues your certificate.",
+	"caa_allows_any_ca":         "Add an issue property to restrict which CAs may issue certificates.",
+	"caa_untrusted_issuer":      "Confirm the authorised CA is intended; remove unexpected issue entries.",
+	"caa_unknown_critical_flag": "Review the critical CAA property; conformant CAs will refuse issuance.",
+	"caa_conflicting_records":   "Remove the no-issuance directive or the conflicting permissive issue entry.",
+	"missing_iodef":             "Add an iodef property, e.g. 0 iodef \"mailto:security@example.com\".",
 }

--- a/internal/store/assessors.sql.go
+++ b/internal/store/assessors.sql.go
@@ -11,6 +11,88 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const assessCreateCAAComplianceFinding = `-- name: AssessCreateCAAComplianceFinding :one
+INSERT INTO caa_compliance_findings (domain_id,
+                                     caa_record_id,
+                                     severity,
+                                     status,
+                                     issue_type,
+                                     standard_name,
+                                     details)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
+ON CONFLICT (domain_id, issue_type)
+    DO UPDATE SET caa_record_id = $2,
+                  severity      = $3,
+                  status        = $4,
+                  standard_name = $6,
+                  details       = $7
+RETURNING (xmax = 0)::boolean AS inserted
+`
+
+type AssessCreateCAAComplianceFindingParams struct {
+	DomainID     pgtype.Int4     `json:"domain_id"`
+	CaaRecordID  pgtype.Int4     `json:"caa_record_id"`
+	Severity     FindingSeverity `json:"severity"`
+	Status       FindingStatus   `json:"status"`
+	IssueType    string          `json:"issue_type"`
+	StandardName pgtype.Text     `json:"standard_name"`
+	Details      pgtype.Text     `json:"details"`
+}
+
+func (q *Queries) AssessCreateCAAComplianceFinding(ctx context.Context, arg AssessCreateCAAComplianceFindingParams) (bool, error) {
+	row := q.db.QueryRow(ctx, assessCreateCAAComplianceFinding,
+		arg.DomainID,
+		arg.CaaRecordID,
+		arg.Severity,
+		arg.Status,
+		arg.IssueType,
+		arg.StandardName,
+		arg.Details,
+	)
+	var inserted bool
+	err := row.Scan(&inserted)
+	return inserted, err
+}
+
+const assessCreateCAAConfigurationFinding = `-- name: AssessCreateCAAConfigurationFinding :one
+INSERT INTO caa_configuration_findings (domain_id,
+                                        caa_record_id,
+                                        severity,
+                                        status,
+                                        issue_type,
+                                        details)
+VALUES ($1, $2, $3, $4, $5, $6)
+ON CONFLICT (domain_id, issue_type)
+    DO UPDATE SET caa_record_id = $2,
+                  severity      = $3,
+                  status        = $4,
+                  details       = $6
+RETURNING (xmax = 0)::boolean AS inserted
+`
+
+type AssessCreateCAAConfigurationFindingParams struct {
+	DomainID    pgtype.Int4     `json:"domain_id"`
+	CaaRecordID pgtype.Int4     `json:"caa_record_id"`
+	Severity    FindingSeverity `json:"severity"`
+	Status      FindingStatus   `json:"status"`
+	IssueType   string          `json:"issue_type"`
+	Details     pgtype.Text     `json:"details"`
+}
+
+func (q *Queries) AssessCreateCAAConfigurationFinding(ctx context.Context, arg AssessCreateCAAConfigurationFindingParams) (bool, error) {
+	row := q.db.QueryRow(ctx, assessCreateCAAConfigurationFinding,
+		arg.DomainID,
+		arg.CaaRecordID,
+		arg.Severity,
+		arg.Status,
+		arg.IssueType,
+		arg.Details,
+	)
+	var inserted bool
+	err := row.Scan(&inserted)
+	return inserted, err
+}
+
 const assessCreateCertificateFinding = `-- name: AssessCreateCertificateFinding :one
 INSERT INTO certificate_findings (domain_id,
                                   certificate_id,
@@ -301,6 +383,97 @@ func (q *Queries) AssessDKIMFindingsByDomainID(ctx context.Context, arg AssessDK
 			&i.IssueType,
 			&i.Details,
 			&i.DkimValue,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const assessGetCAAComplianceFindingsByDomainUID = `-- name: AssessGetCAAComplianceFindingsByDomainUID :many
+SELECT ccf.id, ccf.uid, ccf.domain_id, ccf.caa_record_id, ccf.severity, ccf.status, ccf.issue_type, ccf.standard_name, ccf.details, ccf.created_at, ccf.updated_at
+FROM caa_compliance_findings ccf
+         JOIN domains d ON ccf.domain_id = d.id
+WHERE d.uid = $1
+  AND d.tenant_id = $2
+ORDER BY ccf.severity ASC, ccf.created_at DESC
+`
+
+type AssessGetCAAComplianceFindingsByDomainUIDParams struct {
+	Uid      string      `json:"uid"`
+	TenantID pgtype.Int4 `json:"tenant_id"`
+}
+
+func (q *Queries) AssessGetCAAComplianceFindingsByDomainUID(ctx context.Context, arg AssessGetCAAComplianceFindingsByDomainUIDParams) ([]CaaComplianceFindings, error) {
+	rows, err := q.db.Query(ctx, assessGetCAAComplianceFindingsByDomainUID, arg.Uid, arg.TenantID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []CaaComplianceFindings{}
+	for rows.Next() {
+		var i CaaComplianceFindings
+		if err := rows.Scan(
+			&i.ID,
+			&i.Uid,
+			&i.DomainID,
+			&i.CaaRecordID,
+			&i.Severity,
+			&i.Status,
+			&i.IssueType,
+			&i.StandardName,
+			&i.Details,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const assessGetCAAConfigurationFindingsByDomainUID = `-- name: AssessGetCAAConfigurationFindingsByDomainUID :many
+SELECT ccf.id, ccf.uid, ccf.domain_id, ccf.caa_record_id, ccf.severity, ccf.status, ccf.issue_type, ccf.details, ccf.created_at, ccf.updated_at
+FROM caa_configuration_findings ccf
+         JOIN domains d ON ccf.domain_id = d.id
+WHERE d.uid = $1
+  AND d.tenant_id = $2
+ORDER BY ccf.severity ASC, ccf.created_at DESC
+`
+
+type AssessGetCAAConfigurationFindingsByDomainUIDParams struct {
+	Uid      string      `json:"uid"`
+	TenantID pgtype.Int4 `json:"tenant_id"`
+}
+
+func (q *Queries) AssessGetCAAConfigurationFindingsByDomainUID(ctx context.Context, arg AssessGetCAAConfigurationFindingsByDomainUIDParams) ([]CaaConfigurationFindings, error) {
+	rows, err := q.db.Query(ctx, assessGetCAAConfigurationFindingsByDomainUID, arg.Uid, arg.TenantID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []CaaConfigurationFindings{}
+	for rows.Next() {
+		var i CaaConfigurationFindings
+		if err := rows.Scan(
+			&i.ID,
+			&i.Uid,
+			&i.DomainID,
+			&i.CaaRecordID,
+			&i.Severity,
+			&i.Status,
+			&i.IssueType,
+			&i.Details,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 		); err != nil {
@@ -827,6 +1000,12 @@ open_findings AS (
     UNION ALL
     SELECT domain_id, severity::text FROM cname_redirection_findings
         WHERE status = 'open' AND domain_id = ANY($1::int[])
+    UNION ALL
+    SELECT domain_id, severity::text FROM caa_configuration_findings
+        WHERE status = 'open' AND domain_id = ANY($1::int[])
+    UNION ALL
+    SELECT domain_id, severity::text FROM caa_compliance_findings
+        WHERE status = 'open' AND domain_id = ANY($1::int[])
 )
 SELECT
     ids.domain_id::int AS domain_id,
@@ -967,7 +1146,25 @@ FROM (SELECT sf.uid                AS finding_uid,
       FROM cname_redirection_findings crf
                JOIN domains d ON crf.domain_id = d.id
       WHERE d.tenant_id = $1
-        AND ($2::bool OR crf.status = 'open')) f
+        AND ($2::bool OR crf.status = 'open')
+
+      UNION ALL
+
+      SELECT ccf.uid, d.uid, d.name, 'CAA_CONFIG'::text, ccf.severity, ccf.status,
+             ccf.issue_type, NULL::text, ccf.details, NULL::text, ccf.created_at
+      FROM caa_configuration_findings ccf
+               JOIN domains d ON ccf.domain_id = d.id
+      WHERE d.tenant_id = $1
+        AND ($2::bool OR ccf.status = 'open')
+
+      UNION ALL
+
+      SELECT cpf.uid, d.uid, d.name, 'CAA_COMPLIANCE'::text, cpf.severity, cpf.status,
+             cpf.issue_type, NULL::text, cpf.details, NULL::text, cpf.created_at
+      FROM caa_compliance_findings cpf
+               JOIN domains d ON cpf.domain_id = d.id
+      WHERE d.tenant_id = $1
+        AND ($2::bool OR cpf.status = 'open')) f
 ORDER BY f.domain_name ASC,
          CASE f.severity
              WHEN 'critical' THEN 1
@@ -1206,6 +1403,10 @@ FROM (
         SELECT domain_id, severity::text FROM dangling_cname_findings WHERE status = 'open'
         UNION ALL
         SELECT domain_id, severity::text FROM cname_redirection_findings WHERE status = 'open'
+        UNION ALL
+        SELECT domain_id, severity::text FROM caa_configuration_findings WHERE status = 'open'
+        UNION ALL
+        SELECT domain_id, severity::text FROM caa_compliance_findings WHERE status = 'open'
     ) f ON f.domain_id = d.id
     GROUP BY d.tenant_id, d.id
 ) agg

--- a/internal/ui/findings_handlers.go
+++ b/internal/ui/findings_handlers.go
@@ -89,15 +89,26 @@ func toTenantFindingsView(res service.TenantFindingsResult) templates.TenantFind
 
 // findingKindOrder fixes the type-dropdown ordering; unknown future kinds are
 // appended alphabetically so new assessors surface automatically.
-var findingKindOrder = []string{"SPF", "DKIM", "DMARC", "ZONE", "CERT", "DNSSEC"}
+var findingKindOrder = []string{
+	"SPF",
+	"DKIM",
+	"DMARC",
+	"ZONE",
+	"CERT",
+	"DNSSEC",
+	"CAA_CONFIG",
+	"CAA_COMPLIANCE",
+}
 
 var findingKindLabels = map[string]string{
-	"SPF":    "SPF",
-	"DKIM":   "DKIM",
-	"DMARC":  "DMARC",
-	"ZONE":   "Zone transfer",
-	"CERT":   "Certificate",
-	"DNSSEC": "DNSSEC",
+	"SPF":            "SPF",
+	"DKIM":           "DKIM",
+	"DMARC":          "DMARC",
+	"ZONE":           "Zone transfer",
+	"CERT":           "Certificate",
+	"DNSSEC":         "DNSSEC",
+	"CAA_CONFIG":     "CAA configuration",
+	"CAA_COMPLIANCE": "CAA compliance",
 }
 
 // kindOptions builds the data-driven type dropdown from the faceted KindCounts.

--- a/sql/queries/assessors.sql
+++ b/sql/queries/assessors.sql
@@ -63,6 +63,54 @@ WHERE d.uid = $1
   AND d.tenant_id = $2
 ORDER BY df.severity ASC, df.created_at DESC;
 
+-- name: AssessCreateCAAConfigurationFinding :one
+INSERT INTO caa_configuration_findings (domain_id,
+                                        caa_record_id,
+                                        severity,
+                                        status,
+                                        issue_type,
+                                        details)
+VALUES ($1, $2, $3, $4, $5, $6)
+ON CONFLICT (domain_id, issue_type)
+    DO UPDATE SET caa_record_id = $2,
+                  severity      = $3,
+                  status        = $4,
+                  details       = $6
+RETURNING (xmax = 0)::boolean AS inserted;
+
+-- name: AssessGetCAAConfigurationFindingsByDomainUID :many
+SELECT ccf.*
+FROM caa_configuration_findings ccf
+         JOIN domains d ON ccf.domain_id = d.id
+WHERE d.uid = $1
+  AND d.tenant_id = $2
+ORDER BY ccf.severity ASC, ccf.created_at DESC;
+
+-- name: AssessCreateCAAComplianceFinding :one
+INSERT INTO caa_compliance_findings (domain_id,
+                                     caa_record_id,
+                                     severity,
+                                     status,
+                                     issue_type,
+                                     standard_name,
+                                     details)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
+ON CONFLICT (domain_id, issue_type)
+    DO UPDATE SET caa_record_id = $2,
+                  severity      = $3,
+                  status        = $4,
+                  standard_name = $6,
+                  details       = $7
+RETURNING (xmax = 0)::boolean AS inserted;
+
+-- name: AssessGetCAAComplianceFindingsByDomainUID :many
+SELECT ccf.*
+FROM caa_compliance_findings ccf
+         JOIN domains d ON ccf.domain_id = d.id
+WHERE d.uid = $1
+  AND d.tenant_id = $2
+ORDER BY ccf.severity ASC, ccf.created_at DESC;
+
 -- name: StoreDanglingCnameFinding :one
 INSERT INTO dangling_cname_findings (domain_id,
                                      severity,
@@ -275,6 +323,12 @@ open_findings AS (
     UNION ALL
     SELECT domain_id, severity::text FROM cname_redirection_findings
         WHERE status = 'open' AND domain_id = ANY(@domain_ids::int[])
+    UNION ALL
+    SELECT domain_id, severity::text FROM caa_configuration_findings
+        WHERE status = 'open' AND domain_id = ANY(@domain_ids::int[])
+    UNION ALL
+    SELECT domain_id, severity::text FROM caa_compliance_findings
+        WHERE status = 'open' AND domain_id = ANY(@domain_ids::int[])
 )
 SELECT
     ids.domain_id::int AS domain_id,
@@ -390,7 +444,25 @@ FROM (SELECT sf.uid                AS finding_uid,
       FROM cname_redirection_findings crf
                JOIN domains d ON crf.domain_id = d.id
       WHERE d.tenant_id = @tenant_id
-        AND (@include_compliant::bool OR crf.status = 'open')) f
+        AND (@include_compliant::bool OR crf.status = 'open')
+
+      UNION ALL
+
+      SELECT ccf.uid, d.uid, d.name, 'CAA_CONFIG'::text, ccf.severity, ccf.status,
+             ccf.issue_type, NULL::text, ccf.details, NULL::text, ccf.created_at
+      FROM caa_configuration_findings ccf
+               JOIN domains d ON ccf.domain_id = d.id
+      WHERE d.tenant_id = @tenant_id
+        AND (@include_compliant::bool OR ccf.status = 'open')
+
+      UNION ALL
+
+      SELECT cpf.uid, d.uid, d.name, 'CAA_COMPLIANCE'::text, cpf.severity, cpf.status,
+             cpf.issue_type, NULL::text, cpf.details, NULL::text, cpf.created_at
+      FROM caa_compliance_findings cpf
+               JOIN domains d ON cpf.domain_id = d.id
+      WHERE d.tenant_id = @tenant_id
+        AND (@include_compliant::bool OR cpf.status = 'open')) f
 ORDER BY f.domain_name ASC,
          CASE f.severity
              WHEN 'critical' THEN 1
@@ -438,6 +510,10 @@ FROM (
         SELECT domain_id, severity::text FROM dangling_cname_findings WHERE status = 'open'
         UNION ALL
         SELECT domain_id, severity::text FROM cname_redirection_findings WHERE status = 'open'
+        UNION ALL
+        SELECT domain_id, severity::text FROM caa_configuration_findings WHERE status = 'open'
+        UNION ALL
+        SELECT domain_id, severity::text FROM caa_compliance_findings WHERE status = 'open'
     ) f ON f.domain_id = d.id
     GROUP BY d.tenant_id, d.id
 ) agg


### PR DESCRIPTION
Closes #62. Part of #61 (Tier 1 quick win).

Wires up the dormant `caa_configuration_findings` and `caa_compliance_findings` tables. CAA records are already collected by `ResolveDomainWorker` into `caa_records`, so this is pure data analysis — no new network egress.

## Checks

**Configuration** (`caa_configuration_findings`)
- `caa_missing` — no CAA at apex (`info`, escalates to `low` when a cert is present)
- `caa_allows_any_ca` — CAA exists but no `issue` property restricts issuance (`low`)
- `caa_untrusted_issuer` — `issue`/`issuewild` names a CA outside a built-in allowlist (`low`)
- `caa_unknown_critical_flag` — critical flag on a property gecko can't interpret (`medium`)
- `caa_conflicting_records` — no-issuance directive alongside a permissive `issue` (`medium`)

**Compliance** (`caa_compliance_findings`, carries `standard_name`)
- `caa_required_for_cert` — cert-bearing domain publishes no CAA (`low`)
- `missing_iodef` — no `iodef` reporting property (`info`)

## Notes

- Migration `00024` adds the `UNIQUE (domain_id, issue_type)` constraint both dormant tables were missing; findings upsert on conflict so they auto-resolve on re-scan.
- `AssessCAA` is enqueued **unconditionally** from `ResolveDomainWorker` (not gated like the TXT-dependent email assessment) so a missing CAA record set is still detected.
- Surfaced through the findings API (`kind=CAA_CONFIG|CAA_COMPLIANCE`) and browser UI.
- Issuer allowlist is a built-in list of well-known public CAs; it will drift over time and needs occasional upkeep.

Verified: `go test -race ./...` green, `task audit` clean, `task ci:all` (Dagger lint+test+build) green.