### PR TITLE
minimum record set + SOA hygiene assessor

### DIFF
--- a/assets/migrations/00025_minimum_record_set_unique.sql
+++ b/assets/migrations/00025_minimum_record_set_unique.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE minimum_record_set_findings
+    ADD CONSTRAINT minimum_record_set_findings_domain_id_issue_type_key
+        UNIQUE (domain_id, issue_type);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE minimum_record_set_findings
+    DROP CONSTRAINT minimum_record_set_findings_domain_id_issue_type_key;
+-- +goose StatementEnd

--- a/internal/assessor/assess_minimum_record_set.go
+++ b/internal/assessor/assess_minimum_record_set.go
@@ -1,0 +1,372 @@
+package assessor
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/danielmichaels/gecko/internal/observer"
+	"github.com/danielmichaels/gecko/internal/store"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+const (
+	MinRecordInsufficientNS       = "insufficient_nameservers"
+	MinRecordMissingApexAddress   = "missing_apex_address"
+	MinRecordMissingIPv6          = "missing_ipv6"
+	MinRecordMissingSOA           = "missing_soa"
+	MinRecordMissingMX            = "missing_mx"
+	MinRecordSOATimers            = "soa_timers_out_of_range"
+	MinRecordSOASerial            = "soa_serial_format"
+	MinRecordSOAMNameUnresolvable = "soa_mname_unresolvable"
+	MinRecordSOARName             = "soa_rname_malformed"
+)
+
+const recommendedNameserverCount = 2
+
+// soaTimerRange holds an inclusive RFC 1912 recommended range for a SOA timer.
+type soaTimerRange struct {
+	name   string
+	value  int32
+	lo, hi int32
+}
+
+// AssessMinimumRecordSet checks that an apex domain publishes the records core
+// services depend on (apex address, >=2 NS, SOA, MX when email is intended) and
+// folds in SOA hygiene. It runs only for apex (tld) domains — NS/SOA are
+// zone-apex concepts, so subdomains are skipped. Inputs come from already-stored
+// records; only the SOA MNAME resolvability check performs a (rate-limited) lookup.
+func (a *Assessor) AssessMinimumRecordSet(ctx context.Context, domainUID string) error {
+	domain, err := a.store.DomainsGetByIdentifier(ctx, store.DomainsGetByIdentifierParams{
+		Uid:      domainUID,
+		TenantID: pgtype.Int4{Int32: a.identity.TenantID, Valid: true},
+	})
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("domain %s not found in database", domainUID)
+		}
+		a.logger.ErrorContext(ctx, "Error looking up domain", "domain", domainUID, "error", err)
+		return err
+	}
+
+	if domain.DomainType != store.DomainTypeTld {
+		return nil
+	}
+
+	id := pgtype.Int4{Int32: domain.ID, Valid: true}
+	ns, err := a.store.RecordsGetNSByDomainID(ctx, id)
+	if err != nil {
+		return fmt.Errorf("get NS records: %w", err)
+	}
+	aRecs, err := a.store.RecordsGetAByDomainID(ctx, id)
+	if err != nil {
+		return fmt.Errorf("get A records: %w", err)
+	}
+	aaaa, err := a.store.RecordsGetAAAAByDomainID(ctx, id)
+	if err != nil {
+		return fmt.Errorf("get AAAA records: %w", err)
+	}
+	soa, err := a.store.RecordsGetSOAByDomainID(ctx, id)
+	if err != nil {
+		return fmt.Errorf("get SOA records: %w", err)
+	}
+	mx, err := a.store.RecordsGetMXByDomainID(ctx, id)
+	if err != nil {
+		return fmt.Errorf("get MX records: %w", err)
+	}
+	txt, err := a.store.RecordsGetTXTByDomainID(ctx, id)
+	if err != nil {
+		return fmt.Errorf("get TXT records: %w", err)
+	}
+
+	if err := a.assessNameservers(ctx, domain.ID, ns); err != nil {
+		return err
+	}
+	if err := a.assessApexAddress(ctx, domain.ID, len(aRecs) > 0, len(aaaa) > 0); err != nil {
+		return err
+	}
+	if err := a.assessSOA(ctx, domain.ID, soa); err != nil {
+		return err
+	}
+	return a.assessMailRouting(ctx, domain.ID, mx, txt)
+}
+
+func (a *Assessor) assessNameservers(
+	ctx context.Context,
+	domainID int32,
+	ns []store.NsRecords,
+) error {
+	status := store.FindingStatusResolved
+	details := fmt.Sprintf("%d nameservers published", len(ns))
+	if len(ns) < recommendedNameserverCount {
+		status = store.FindingStatusOpen
+		details = fmt.Sprintf(
+			"Only %d nameserver(s) published; RFC 2182 recommends at least %d on separate networks",
+			len(ns), recommendedNameserverCount,
+		)
+	}
+	return a.createMinRecordFinding(ctx, domainID,
+		store.FindingSeverityHigh, status, MinRecordInsufficientNS, "NS", details)
+}
+
+func (a *Assessor) assessApexAddress(
+	ctx context.Context,
+	domainID int32,
+	hasA, hasAAAA bool,
+) error {
+	apexStatus := store.FindingStatusResolved
+	apexDetails := "Apex resolves to an address record"
+	if !hasA && !hasAAAA {
+		apexStatus = store.FindingStatusOpen
+		apexDetails = "Apex publishes no A or AAAA record, so it does not resolve to an address"
+	}
+	if err := a.createMinRecordFinding(ctx, domainID,
+		store.FindingSeverityMedium, apexStatus, MinRecordMissingApexAddress, "A", apexDetails); err != nil {
+		return err
+	}
+
+	// IPv6 is advisory and only meaningful once the apex resolves over IPv4.
+	if !hasA {
+		return nil
+	}
+	ipv6Status := store.FindingStatusResolved
+	ipv6Details := "Apex publishes an AAAA record"
+	if !hasAAAA {
+		ipv6Status = store.FindingStatusOpen
+		ipv6Details = "Apex resolves over IPv4 but publishes no AAAA record"
+	}
+	return a.createMinRecordFinding(ctx, domainID,
+		store.FindingSeverityInfo, ipv6Status, MinRecordMissingIPv6, "AAAA", ipv6Details)
+}
+
+func (a *Assessor) assessSOA(ctx context.Context, domainID int32, soa []store.SoaRecords) error {
+	if len(soa) == 0 {
+		return a.createMinRecordFinding(ctx, domainID,
+			store.FindingSeverityMedium, store.FindingStatusOpen, MinRecordMissingSOA, "SOA",
+			"No SOA record published at the zone apex")
+	}
+	if err := a.createMinRecordFinding(ctx, domainID,
+		store.FindingSeverityMedium, store.FindingStatusResolved, MinRecordMissingSOA, "SOA",
+		"SOA record present"); err != nil {
+		return err
+	}
+
+	rec := soa[0]
+	if err := a.assessSOATimers(ctx, domainID, rec); err != nil {
+		return err
+	}
+	if err := a.assessSOASerial(ctx, domainID, rec); err != nil {
+		return err
+	}
+	if err := a.assessSOAMName(ctx, domainID, rec); err != nil {
+		return err
+	}
+	return a.assessSOARName(ctx, domainID, rec)
+}
+
+func (a *Assessor) assessSOATimers(
+	ctx context.Context,
+	domainID int32,
+	rec store.SoaRecords,
+) error {
+	ranges := []soaTimerRange{
+		{"refresh", rec.Refresh, 1200, 86400},
+		{"retry", rec.Retry, 120, 7200},
+		{"expire", rec.Expire, 604800, 2419200},
+		{"minimum", rec.MinimumTtl, 300, 86400},
+	}
+	var offenders []string
+	for _, r := range ranges {
+		if r.value < r.lo || r.value > r.hi {
+			offenders = append(
+				offenders,
+				fmt.Sprintf("%s=%d (recommended %d-%d)", r.name, r.value, r.lo, r.hi),
+			)
+		}
+	}
+	status := store.FindingStatusResolved
+	details := "SOA timers fall within RFC 1912 recommended ranges"
+	if len(offenders) > 0 {
+		status = store.FindingStatusOpen
+		details = "SOA timers outside RFC 1912 recommended ranges: " + strings.Join(offenders, ", ")
+	}
+	return a.createMinRecordFinding(ctx, domainID,
+		store.FindingSeverityLow, status, MinRecordSOATimers, "SOA", details)
+}
+
+func (a *Assessor) assessSOASerial(
+	ctx context.Context,
+	domainID int32,
+	rec store.SoaRecords,
+) error {
+	status := store.FindingStatusResolved
+	details := "SOA serial uses the recommended YYYYMMDDnn format"
+	if !serialLooksDateBased(rec.Serial) {
+		status = store.FindingStatusOpen
+		details = fmt.Sprintf(
+			"SOA serial %d is not in the advisory date-based YYYYMMDDnn format",
+			rec.Serial,
+		)
+	}
+	return a.createMinRecordFinding(ctx, domainID,
+		store.FindingSeverityInfo, status, MinRecordSOASerial, "SOA", details)
+}
+
+func (a *Assessor) assessSOAMName(ctx context.Context, domainID int32, rec store.SoaRecords) error {
+	mname := strings.TrimSuffix(strings.TrimSpace(rec.Nameserver), ".")
+	status := store.FindingStatusResolved
+	details := fmt.Sprintf("SOA MNAME %q resolves to an address", mname)
+	if !a.hostResolves(mname) {
+		status = store.FindingStatusOpen
+		details = fmt.Sprintf("SOA MNAME %q does not resolve to an A or AAAA record", mname)
+	}
+	return a.createMinRecordFinding(ctx, domainID,
+		store.FindingSeverityMedium, status, MinRecordSOAMNameUnresolvable, "SOA", details)
+}
+
+func (a *Assessor) assessSOARName(ctx context.Context, domainID int32, rec store.SoaRecords) error {
+	status := store.FindingStatusResolved
+	details := "SOA RNAME is a well-formed responsible-party address"
+	if !rnameWellFormed(rec.Email) {
+		status = store.FindingStatusOpen
+		details = fmt.Sprintf(
+			"SOA RNAME %q is not a well-formed responsible-party address",
+			rec.Email,
+		)
+	}
+	return a.createMinRecordFinding(ctx, domainID,
+		store.FindingSeverityLow, status, MinRecordSOARName, "SOA", details)
+}
+
+func (a *Assessor) assessMailRouting(
+	ctx context.Context,
+	domainID int32,
+	mx []store.MxRecords,
+	txt []store.TxtRecords,
+) error {
+	var hasMX, hasNullMX bool
+	for _, m := range mx {
+		if strings.TrimSuffix(strings.TrimSpace(m.Target), ".") == "" {
+			hasNullMX = true
+		} else {
+			hasMX = true
+		}
+	}
+
+	switch {
+	case hasMX || hasNullMX:
+		details := "Domain publishes MX records"
+		if hasNullMX && !hasMX {
+			details = "Domain publishes an explicit null-MX (RFC 7505), declaring it sends/receives no mail"
+		}
+		return a.createMinRecordFinding(
+			ctx,
+			domainID,
+			store.FindingSeverityLow,
+			store.FindingStatusResolved,
+			MinRecordMissingMX,
+			"MX",
+			details,
+		)
+	case hasEmailIntent(txt):
+		return a.createMinRecordFinding(ctx, domainID,
+			store.FindingSeverityLow, store.FindingStatusOpen, MinRecordMissingMX, "MX",
+			"Domain publishes email-authentication records (SPF/DMARC) but no MX or null-MX")
+	default:
+		// No mail signal and no MX: nothing to assert.
+		return nil
+	}
+}
+
+// hostResolves reports whether a hostname has an A or AAAA record. This is the
+// only outbound lookup in the assessor; it goes through the shared rate-limited,
+// cached resolver.
+func (a *Assessor) hostResolves(host string) bool {
+	if host == "" {
+		return false
+	}
+	if v, ok := a.dnsClient.LookupA(host); ok && len(v) > 0 {
+		return true
+	}
+	if v, ok := a.dnsClient.LookupAAAA(host); ok && len(v) > 0 {
+		return true
+	}
+	return false
+}
+
+// serialLooksDateBased reports whether a SOA serial plausibly follows the
+// advisory YYYYMMDDnn convention (RFC 1912).
+func serialLooksDateBased(serial int64) bool {
+	if serial < 1900010100 || serial > 2999123199 {
+		return false
+	}
+	date := serial / 100
+	year := date / 10000
+	month := (date / 100) % 100
+	day := date % 100
+	return year >= 1970 && year <= 2100 && month >= 1 && month <= 12 && day >= 1 && day <= 31
+}
+
+// rnameWellFormed reports whether a SOA RNAME (DNS-form responsible party, e.g.
+// "hostmaster.example.com.") converts to a plausible email: a non-empty local
+// part and a dotted domain part.
+func rnameWellFormed(rname string) bool {
+	r := strings.TrimSuffix(strings.TrimSpace(rname), ".")
+	if r == "" {
+		return false
+	}
+	dot := strings.Index(r, ".")
+	if dot <= 0 || dot == len(r)-1 {
+		return false
+	}
+	local, domain := r[:dot], r[dot+1:]
+	return local != "" && strings.Contains(domain, ".")
+}
+
+func hasEmailIntent(txt []store.TxtRecords) bool {
+	for _, t := range txt {
+		v := strings.ToLower(t.Value)
+		if strings.Contains(v, "v=spf1") || strings.Contains(v, "v=dmarc1") {
+			return true
+		}
+	}
+	return false
+}
+
+func (a *Assessor) createMinRecordFinding(
+	ctx context.Context,
+	domainID int32,
+	severity store.FindingSeverity,
+	status store.FindingStatus,
+	issueType, missingRecordType, details string,
+) error {
+	if _, err := a.store.AssessCreateMinimumRecordSetFinding(ctx, store.AssessCreateMinimumRecordSetFindingParams{
+		DomainID:          pgtype.Int4{Int32: domainID, Valid: true},
+		Severity:          severity,
+		Status:            status,
+		IssueType:         issueType,
+		MissingRecordType: missingRecordType,
+		Details:           pgtype.Text{String: details, Valid: details != ""},
+	}); err != nil {
+		a.logger.WarnContext(ctx, "failed to create minimum record set finding",
+			"issue_type", issueType, "error", err)
+		return fmt.Errorf("create minimum record set finding %s: %w", issueType, err)
+	}
+
+	payload := observer.PayloadJSON(map[string]any{
+		"issue_type":          issueType,
+		"missing_record_type": missingRecordType,
+		"severity":            string(severity),
+		"status":              string(status),
+		"details":             details,
+	})
+	if oErr := observer.New(a.store).RecordFindingChange(
+		ctx, a.identity, observer.EntityMinimumRecordSetFinding, issueType, payload,
+	); oErr != nil {
+		a.logger.WarnContext(ctx, "failed to emit minimum record set finding observation",
+			"issue_type", issueType, "error", oErr)
+	}
+	return nil
+}

--- a/internal/assessor/assess_minimum_record_set_test.go
+++ b/internal/assessor/assess_minimum_record_set_test.go
@@ -1,0 +1,318 @@
+package assessor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/danielmichaels/gecko/internal/dnsclient"
+	"github.com/danielmichaels/gecko/internal/observer"
+	"github.com/danielmichaels/gecko/internal/store"
+	"github.com/danielmichaels/gecko/internal/testhelpers"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/miekg/dns"
+)
+
+func minRecordFindingByIssueType(
+	findings []store.MinimumRecordSetFindings,
+	issueType string,
+) (store.MinimumRecordSetFindings, bool) {
+	for _, f := range findings {
+		if f.IssueType == issueType {
+			return f, true
+		}
+	}
+	return store.MinimumRecordSetFindings{}, false
+}
+
+func TestAssessMinimumRecordSet(t *testing.T) {
+	ctx := context.Background()
+	pgContainer, err := testhelpers.CreatePostgresContainer(ctx)
+	if err != nil {
+		t.Fatalf("Failed to create postgres container: %v", err)
+	}
+	defer pgContainer.Close(ctx)
+
+	mockServer, err := testhelpers.NewMockDNSServer()
+	if err != nil {
+		t.Fatalf("Failed to create mock DNS server: %v", err)
+	}
+	if err := mockServer.Start(); err != nil {
+		t.Fatalf("Failed to start mock DNS server: %v", err)
+	}
+	defer func() { _ = mockServer.Stop() }()
+
+	dnsClient := dnsclient.New(
+		dnsclient.WithServers([]string{mockServer.ListenAddr}),
+		dnsclient.WithLogger(testhelpers.TestLogger),
+	)
+
+	newDomain := func(t *testing.T, name string, dtype store.DomainType) store.DomainsCreateRow {
+		t.Helper()
+		d, err := pgContainer.Queries.DomainsCreate(ctx, store.DomainsCreateParams{
+			TenantID:   pgtype.Int4{Int32: 1, Valid: true},
+			Name:       name,
+			DomainType: dtype,
+			Source:     store.DomainSourceUserSupplied,
+			Status:     store.DomainStatusActive,
+		})
+		if err != nil {
+			t.Fatalf("Failed to create domain %s: %v", name, err)
+		}
+		return d
+	}
+
+	seedA := func(t *testing.T, domainID int32, ip string) {
+		t.Helper()
+		if _, err := pgContainer.Queries.RecordsCreateA(ctx, store.RecordsCreateAParams{
+			DomainID: pgtype.Int4{Int32: domainID, Valid: true}, Ipv4Address: ip,
+		}); err != nil {
+			t.Fatalf("seed A: %v", err)
+		}
+	}
+	seedAAAA := func(t *testing.T, domainID int32, ip string) {
+		t.Helper()
+		if _, err := pgContainer.Queries.RecordsCreateAAAA(ctx, store.RecordsCreateAAAAParams{
+			DomainID: pgtype.Int4{Int32: domainID, Valid: true}, Ipv6Address: ip,
+		}); err != nil {
+			t.Fatalf("seed AAAA: %v", err)
+		}
+	}
+	seedNS := func(t *testing.T, domainID int32, ns string) {
+		t.Helper()
+		if _, err := pgContainer.Queries.RecordsCreateNS(ctx, store.RecordsCreateNSParams{
+			DomainID: pgtype.Int4{Int32: domainID, Valid: true}, Nameserver: ns,
+		}); err != nil {
+			t.Fatalf("seed NS: %v", err)
+		}
+	}
+	seedMX := func(t *testing.T, domainID int32, pref int32, target string) {
+		t.Helper()
+		if _, err := pgContainer.Queries.RecordsCreateMX(ctx, store.RecordsCreateMXParams{
+			DomainID: pgtype.Int4{Int32: domainID, Valid: true}, Preference: pref, Target: target,
+		}); err != nil {
+			t.Fatalf("seed MX: %v", err)
+		}
+	}
+	seedTXT := func(t *testing.T, domainID int32, value string) {
+		t.Helper()
+		if _, err := pgContainer.Queries.RecordsCreateTXT(ctx, store.RecordsCreateTXTParams{
+			DomainID: pgtype.Int4{Int32: domainID, Valid: true}, Value: value,
+		}); err != nil {
+			t.Fatalf("seed TXT: %v", err)
+		}
+	}
+	seedSOA := func(t *testing.T, domainID int32, p store.RecordsCreateSOAParams) {
+		t.Helper()
+		p.DomainID = pgtype.Int4{Int32: domainID, Valid: true}
+		if _, err := pgContainer.Queries.RecordsCreateSOA(ctx, p); err != nil {
+			t.Fatalf("seed SOA: %v", err)
+		}
+	}
+	mockA := func(t *testing.T, name string) {
+		t.Helper()
+		if err := mockServer.AddRecord(name, dns.TypeA, 3600, "192.0.2.1"); err != nil {
+			t.Fatalf("mock A: %v", err)
+		}
+	}
+	// healthySOA returns a well-formed SOA with all timers in range, a date-based
+	// serial, a resolvable MNAME and a valid RNAME.
+	healthySOA := func(t *testing.T, name string) store.RecordsCreateSOAParams {
+		t.Helper()
+		mockA(t, "ns1."+name)
+		return store.RecordsCreateSOAParams{
+			Nameserver: "ns1." + name,
+			Email:      "hostmaster." + name,
+			Serial:     2026061501,
+			Refresh:    7200,
+			Retry:      3600,
+			Expire:     1209600,
+			MinimumTtl: 3600,
+		}
+	}
+
+	run := func(t *testing.T, d store.DomainsCreateRow) {
+		t.Helper()
+		a := NewAssessor(Config{
+			Store:     pgContainer.Queries,
+			Logger:    testhelpers.TestLogger,
+			DNSClient: dnsClient,
+			Identity: observer.DomainIdentity{
+				TenantID: 1, DomainID: d.ID, DomainUID: d.Uid, DomainName: d.Name,
+			},
+		})
+		if err := a.AssessMinimumRecordSet(ctx, d.Uid); err != nil {
+			t.Fatalf("AssessMinimumRecordSet failed: %v", err)
+		}
+	}
+	get := func(t *testing.T, d store.DomainsCreateRow) []store.MinimumRecordSetFindings {
+		t.Helper()
+		f, err := pgContainer.Queries.AssessGetMinimumRecordSetFindingsByDomainUID(ctx,
+			store.AssessGetMinimumRecordSetFindingsByDomainUIDParams{
+				Uid: d.Uid, TenantID: pgtype.Int4{Int32: 1, Valid: true},
+			})
+		if err != nil {
+			t.Fatalf("get findings: %v", err)
+		}
+		return f
+	}
+	assertOpen := func(t *testing.T, d store.DomainsCreateRow, issueType string, sev store.FindingSeverity) {
+		t.Helper()
+		f, ok := minRecordFindingByIssueType(get(t, d), issueType)
+		if !ok {
+			t.Fatalf("expected %s finding", issueType)
+		}
+		if f.Severity != sev {
+			t.Errorf("%s: expected %s severity, got %s", issueType, sev, f.Severity)
+		}
+		if f.Status != store.FindingStatusOpen {
+			t.Errorf("%s: expected open status, got %s", issueType, f.Status)
+		}
+	}
+
+	t.Run("subdomain is skipped entirely", func(t *testing.T) {
+		d := newDomain(t, "www.sub.test", store.DomainTypeSubdomain)
+		run(t, d)
+		if findings := get(t, d); len(findings) != 0 {
+			t.Errorf("expected no findings for a subdomain, got %d", len(findings))
+		}
+	})
+
+	t.Run("apex with fewer than two NS is a high finding", func(t *testing.T) {
+		d := newDomain(t, "one-ns.test", store.DomainTypeTld)
+		seedNS(t, d.ID, "ns1.one-ns.test")
+		run(t, d)
+		assertOpen(t, d, MinRecordInsufficientNS, store.FindingSeverityHigh)
+	})
+
+	t.Run("two NS records resolve the nameserver finding", func(t *testing.T) {
+		d := newDomain(t, "two-ns.test", store.DomainTypeTld)
+		seedNS(t, d.ID, "ns1.two-ns.test")
+		seedNS(t, d.ID, "ns2.two-ns.test")
+		run(t, d)
+		f, ok := minRecordFindingByIssueType(get(t, d), MinRecordInsufficientNS)
+		if !ok || f.Status != store.FindingStatusResolved {
+			t.Errorf("expected resolved insufficient_nameservers, got %+v ok=%v", f, ok)
+		}
+	})
+
+	t.Run("apex with no address record is medium", func(t *testing.T) {
+		d := newDomain(t, "no-addr.test", store.DomainTypeTld)
+		run(t, d)
+		assertOpen(t, d, MinRecordMissingApexAddress, store.FindingSeverityMedium)
+	})
+
+	t.Run("IPv4 only yields an informational IPv6 finding", func(t *testing.T) {
+		d := newDomain(t, "v4-only.test", store.DomainTypeTld)
+		seedA(t, d.ID, "192.0.2.10")
+		run(t, d)
+		assertOpen(t, d, MinRecordMissingIPv6, store.FindingSeverityInfo)
+		if f, ok := minRecordFindingByIssueType(get(t, d), MinRecordMissingApexAddress); ok &&
+			f.Status == store.FindingStatusOpen {
+			t.Error("did not expect open missing_apex_address when A record present")
+		}
+	})
+
+	t.Run("missing SOA is medium", func(t *testing.T) {
+		d := newDomain(t, "no-soa.test", store.DomainTypeTld)
+		seedA(t, d.ID, "192.0.2.20")
+		seedAAAA(t, d.ID, "2001:db8::20")
+		run(t, d)
+		assertOpen(t, d, MinRecordMissingSOA, store.FindingSeverityMedium)
+	})
+
+	t.Run("SOA timers out of range is low", func(t *testing.T) {
+		d := newDomain(t, "bad-timers.test", store.DomainTypeTld)
+		soa := healthySOA(t, "bad-timers.test")
+		soa.Refresh = 30 // below RFC 1912 lower bound
+		seedSOA(t, d.ID, soa)
+		run(t, d)
+		assertOpen(t, d, MinRecordSOATimers, store.FindingSeverityLow)
+	})
+
+	t.Run("non-date serial is an informational advisory", func(t *testing.T) {
+		d := newDomain(t, "bad-serial.test", store.DomainTypeTld)
+		soa := healthySOA(t, "bad-serial.test")
+		soa.Serial = 7 // not YYYYMMDDnn
+		seedSOA(t, d.ID, soa)
+		run(t, d)
+		assertOpen(t, d, MinRecordSOASerial, store.FindingSeverityInfo)
+	})
+
+	t.Run("unresolvable MNAME is medium", func(t *testing.T) {
+		d := newDomain(t, "bad-mname.test", store.DomainTypeTld)
+		soa := store.RecordsCreateSOAParams{
+			Nameserver: "ns1.unreachable-mname.test", // never registered in the mock
+			Email:      "hostmaster.bad-mname.test",
+			Serial:     2026061501, Refresh: 7200, Retry: 3600, Expire: 1209600, MinimumTtl: 3600,
+		}
+		seedSOA(t, d.ID, soa)
+		run(t, d)
+		assertOpen(t, d, MinRecordSOAMNameUnresolvable, store.FindingSeverityMedium)
+	})
+
+	t.Run("malformed RNAME is low", func(t *testing.T) {
+		d := newDomain(t, "bad-rname.test", store.DomainTypeTld)
+		soa := healthySOA(t, "bad-rname.test")
+		soa.Email = "not-an-email"
+		seedSOA(t, d.ID, soa)
+		run(t, d)
+		assertOpen(t, d, MinRecordSOARName, store.FindingSeverityLow)
+	})
+
+	t.Run("email-intent without MX is low", func(t *testing.T) {
+		d := newDomain(t, "mail-no-mx.test", store.DomainTypeTld)
+		seedTXT(t, d.ID, "v=spf1 include:_spf.example.com ~all")
+		run(t, d)
+		assertOpen(t, d, MinRecordMissingMX, store.FindingSeverityLow)
+	})
+
+	t.Run("null MX with email intent is compliant", func(t *testing.T) {
+		d := newDomain(t, "null-mx.test", store.DomainTypeTld)
+		seedTXT(t, d.ID, "v=spf1 -all")
+		seedMX(t, d.ID, 0, ".")
+		run(t, d)
+		if f, ok := minRecordFindingByIssueType(get(t, d), MinRecordMissingMX); ok &&
+			f.Status == store.FindingStatusOpen {
+			t.Error("null MX should not produce an open missing_mx finding")
+		}
+	})
+
+	t.Run("no email intent and no MX produces no MX finding", func(t *testing.T) {
+		d := newDomain(t, "no-mail.test", store.DomainTypeTld)
+		run(t, d)
+		if _, ok := minRecordFindingByIssueType(get(t, d), MinRecordMissingMX); ok {
+			t.Error("did not expect a missing_mx finding for a domain with no email intent")
+		}
+	})
+
+	t.Run("fully healthy apex has no open findings", func(t *testing.T) {
+		d := newDomain(t, "healthy.test", store.DomainTypeTld)
+		seedNS(t, d.ID, "ns1.healthy.test")
+		seedNS(t, d.ID, "ns2.healthy.test")
+		seedA(t, d.ID, "192.0.2.30")
+		seedAAAA(t, d.ID, "2001:db8::30")
+		seedSOA(t, d.ID, healthySOA(t, "healthy.test"))
+		seedMX(t, d.ID, 10, "mail.healthy.test")
+		run(t, d)
+		for _, f := range get(t, d) {
+			if f.Status == store.FindingStatusOpen {
+				t.Errorf("unexpected open finding %s on a healthy apex", f.IssueType)
+			}
+		}
+	})
+
+	t.Run("re-running does not duplicate findings", func(t *testing.T) {
+		d := newDomain(t, "idempotent.test", store.DomainTypeTld)
+		run(t, d)
+		run(t, d)
+		count := 0
+		for _, f := range get(t, d) {
+			if f.IssueType == MinRecordInsufficientNS {
+				count++
+			}
+		}
+		if count != 1 {
+			t.Errorf("expected exactly one insufficient_nameservers finding, got %d", count)
+		}
+	})
+}

--- a/internal/jobs/assess_jobs.go
+++ b/internal/jobs/assess_jobs.go
@@ -298,3 +298,50 @@ func (w *AssessCAAWorker) Work(
 	)
 	return nil
 }
+
+type AssessMinimumRecordSetArgs struct {
+	DomainJobArgs
+}
+
+func (AssessMinimumRecordSetArgs) InsertOpts() river.InsertOpts {
+	return river.InsertOpts{
+		Queue: queueAssessor,
+	}
+}
+func (AssessMinimumRecordSetArgs) Kind() string { return "assess_minimum_record_set" }
+
+type AssessMinimumRecordSetWorker struct {
+	river.WorkerDefaults[AssessMinimumRecordSetArgs]
+	Logger   slog.Logger
+	Store    *store.Queries
+	PgxPool  *pgxpool.Pool
+	Resolver dnsclient.Resolver
+}
+
+func (w *AssessMinimumRecordSetWorker) Work(
+	ctx context.Context,
+	job *river.Job[AssessMinimumRecordSetArgs],
+) error {
+	ctx = tracing.WithNewTraceID(ctx, false)
+	start := time.Now()
+	w.Logger.InfoContext(ctx, "assess minimum record set started", "domain", job.Args.DomainUID)
+	a := assessor.NewAssessor(assessor.Config{
+		Logger:    &w.Logger,
+		Store:     w.Store,
+		DNSClient: w.Resolver,
+		Identity:  job.Args.Identity(),
+	})
+	if err := a.AssessMinimumRecordSet(ctx, job.Args.DomainUID); err != nil {
+		return err
+	}
+
+	w.Logger.InfoContext(
+		ctx,
+		"assess minimum record set complete",
+		"domain",
+		job.Args.DomainUID,
+		"duration",
+		time.Since(start),
+	)
+	return nil
+}

--- a/internal/jobs/enumerate_jobs.go
+++ b/internal/jobs/enumerate_jobs.go
@@ -247,6 +247,14 @@ func (w *ResolveDomainWorker) Work(ctx context.Context, job *river.Job[ResolveDo
 			"domain", job.Args.DomainUID, "error", err)
 	}
 
+	// Minimum record set assessment runs unconditionally; missing essential
+	// records are findings, and the assessor itself gates on apex domains.
+	if err := enqueueAssessment(ctx, w.PgxPool, &w.Logger, job.Args.DomainUID,
+		AssessMinimumRecordSetArgs{DomainJobArgs: job.Args.DomainJobArgs}); err != nil {
+		w.Logger.WarnContext(ctx, "failed to queue minimum record set assessment",
+			"domain", job.Args.DomainUID, "error", err)
+	}
+
 	// Email security assessment is data-dependent: enqueue only when TXT records
 	// were discovered (SPF/DKIM/DMARC live in TXT).
 	if len(resolved.TXT.Entries) > 0 {

--- a/internal/jobs/river.go
+++ b/internal/jobs/river.go
@@ -180,6 +180,15 @@ func New(ctx context.Context, cfg Config) (*river.Client[pgx.Tx], error) {
 				Resolver: cfg.Resolver,
 			},
 		)
+		river.AddWorker(
+			rw,
+			&AssessMinimumRecordSetWorker{
+				Logger:   *cfg.Logger,
+				Store:    cfg.Store,
+				PgxPool:  cfg.PgxPool,
+				Resolver: cfg.Resolver,
+			},
+		)
 		// maintenance
 		river.AddWorker(rw, &PurgeDNSCacheWorker{Logger: *cfg.Logger, Store: cfg.Store})
 		river.AddWorker(rw, &RefreshTenantStatsWorker{Logger: *cfg.Logger, Store: cfg.Store})

--- a/internal/observer/recorder.go
+++ b/internal/observer/recorder.go
@@ -56,6 +56,8 @@ const (
 	EntityCAAConfigurationFinding = "caa_configuration_finding"
 	EntityCAAComplianceFinding    = "caa_compliance_finding"
 
+	EntityMinimumRecordSetFinding = "minimum_record_set_finding"
+
 	// EntityDomain is used only on lifecycle NOTIFY signals (create/delete/status),
 	// never stored as an observation — a domain's existence is the projection
 	// itself. It lets the UI refresh on changes that write no observation row.

--- a/internal/server/findings_handlers.go
+++ b/internal/server/findings_handlers.go
@@ -44,7 +44,7 @@ func toFindingItem(f service.FindingView) FindingItem {
 
 type FindingsListInput struct {
 	Severity         string `query:"severity"          example:"crit"  doc:"Filter by tier: crit|high|med|low. Optional." enum:"crit,high,med,low,"`
-	Kind             string `query:"kind"              example:"SPF"   doc:"Filter by type: SPF|DKIM|DMARC|ZONE|CERT|DNSSEC|CAA_CONFIG|CAA_COMPLIANCE. Optional." enum:"SPF,DKIM,DMARC,ZONE,CERT,DNSSEC,CAA_CONFIG,CAA_COMPLIANCE,"`
+	Kind             string `query:"kind"              example:"SPF"   doc:"Filter by type: SPF|DKIM|DMARC|ZONE|CERT|DNSSEC|CAA_CONFIG|CAA_COMPLIANCE|MIN_RECORDS. Optional." enum:"SPF,DKIM,DMARC,ZONE,CERT,DNSSEC,CAA_CONFIG,CAA_COMPLIANCE,MIN_RECORDS,"`
 	DomainQuery      string `query:"q"                 example:"acme"  doc:"Case-insensitive domain-name substring. Optional."`
 	IncludeCompliant bool   `query:"include_compliant" example:"false" doc:"Include compliant/closed findings. Optional."`
 	PaginationQuery

--- a/internal/service/findings.go
+++ b/internal/service/findings.go
@@ -191,6 +191,16 @@ func (s *FindingsService) ListByDomain(
 			))
 		}
 	}
+	if minRecords, err := s.DB.AssessGetMinimumRecordSetFindingsByDomainUID(ctx, store.AssessGetMinimumRecordSetFindingsByDomainUIDParams{
+		Uid:      domainUID,
+		TenantID: tenantID,
+	}); err == nil {
+		for _, f := range minRecords {
+			findings = append(findings, mapStandardFinding(
+				"MIN_RECORDS", f.Severity, f.Status, f.IssueType, f.Details,
+			))
+		}
+	}
 
 	sort.SliceStable(findings, func(i, j int) bool {
 		return severityRank(findings[i].Severity) < severityRank(findings[j].Severity)
@@ -591,6 +601,15 @@ var findingTitles = map[string]string{
 	"caa_conflicting_records":   "CAA issuance policy conflicts",
 	"caa_required_for_cert":     "Cert-bearing domain has no CAA",
 	"missing_iodef":             "CAA has no iodef reporting endpoint",
+	"insufficient_nameservers":  "Fewer than two nameservers",
+	"missing_apex_address":      "Apex has no A/AAAA record",
+	"missing_ipv6":              "No IPv6 (AAAA) at apex",
+	"missing_soa":               "No SOA record at apex",
+	"missing_mx":                "No MX record for a mail-intended domain",
+	"soa_timers_out_of_range":   "SOA timers outside recommended ranges",
+	"soa_serial_format":         "SOA serial not in YYYYMMDDnn format",
+	"soa_mname_unresolvable":    "SOA primary master does not resolve",
+	"soa_rname_malformed":       "SOA responsible-party address malformed",
 }
 
 // findingDescriptions holds static descriptions for findings whose body text is
@@ -623,4 +642,12 @@ var findingFixes = map[string]string{
 	"caa_unknown_critical_flag": "Review the critical CAA property; conformant CAs will refuse issuance.",
 	"caa_conflicting_records":   "Remove the no-issuance directive or the conflicting permissive issue entry.",
 	"missing_iodef":             "Add an iodef property, e.g. 0 iodef \"mailto:security@example.com\".",
+	"insufficient_nameservers":  "Publish at least two nameservers on separate networks (RFC 2182).",
+	"missing_apex_address":      "Publish an A and/or AAAA record at the apex.",
+	"missing_ipv6":              "Add an AAAA record to make the apex reachable over IPv6.",
+	"missing_soa":               "Ensure the zone publishes a SOA record at its apex.",
+	"missing_mx":                "Publish an MX record, or an explicit null-MX (0 .) if the domain sends no mail.",
+	"soa_timers_out_of_range":   "Adjust SOA refresh/retry/expire/minimum to RFC 1912 ranges.",
+	"soa_mname_unresolvable":    "Ensure the SOA MNAME (primary master) resolves to an address.",
+	"soa_rname_malformed":       "Set a valid SOA RNAME, e.g. hostmaster.example.com.",
 }

--- a/internal/store/assessors.sql.go
+++ b/internal/store/assessors.sql.go
@@ -306,6 +306,45 @@ func (q *Queries) AssessCreateDNSSECFinding(ctx context.Context, arg AssessCreat
 	return inserted, err
 }
 
+const assessCreateMinimumRecordSetFinding = `-- name: AssessCreateMinimumRecordSetFinding :one
+INSERT INTO minimum_record_set_findings (domain_id,
+                                         severity,
+                                         status,
+                                         issue_type,
+                                         missing_record_type,
+                                         details)
+VALUES ($1, $2, $3, $4, $5, $6)
+ON CONFLICT (domain_id, issue_type)
+    DO UPDATE SET severity            = $2,
+                  status              = $3,
+                  missing_record_type = $5,
+                  details             = $6
+RETURNING (xmax = 0)::boolean AS inserted
+`
+
+type AssessCreateMinimumRecordSetFindingParams struct {
+	DomainID          pgtype.Int4     `json:"domain_id"`
+	Severity          FindingSeverity `json:"severity"`
+	Status            FindingStatus   `json:"status"`
+	IssueType         string          `json:"issue_type"`
+	MissingRecordType string          `json:"missing_record_type"`
+	Details           pgtype.Text     `json:"details"`
+}
+
+func (q *Queries) AssessCreateMinimumRecordSetFinding(ctx context.Context, arg AssessCreateMinimumRecordSetFindingParams) (bool, error) {
+	row := q.db.QueryRow(ctx, assessCreateMinimumRecordSetFinding,
+		arg.DomainID,
+		arg.Severity,
+		arg.Status,
+		arg.IssueType,
+		arg.MissingRecordType,
+		arg.Details,
+	)
+	var inserted bool
+	err := row.Scan(&inserted)
+	return inserted, err
+}
+
 const assessCreateSPFFinding = `-- name: AssessCreateSPFFinding :one
 INSERT INTO spf_findings (domain_id,
                           txt_record_id,
@@ -797,6 +836,51 @@ func (q *Queries) AssessGetDanglingCnameFindingsByDomainUID(ctx context.Context,
 	return items, nil
 }
 
+const assessGetMinimumRecordSetFindingsByDomainUID = `-- name: AssessGetMinimumRecordSetFindingsByDomainUID :many
+SELECT mrf.id, mrf.uid, mrf.domain_id, mrf.severity, mrf.status, mrf.issue_type, mrf.missing_record_type, mrf.details, mrf.created_at, mrf.updated_at
+FROM minimum_record_set_findings mrf
+         JOIN domains d ON mrf.domain_id = d.id
+WHERE d.uid = $1
+  AND d.tenant_id = $2
+ORDER BY mrf.severity ASC, mrf.created_at DESC
+`
+
+type AssessGetMinimumRecordSetFindingsByDomainUIDParams struct {
+	Uid      string      `json:"uid"`
+	TenantID pgtype.Int4 `json:"tenant_id"`
+}
+
+func (q *Queries) AssessGetMinimumRecordSetFindingsByDomainUID(ctx context.Context, arg AssessGetMinimumRecordSetFindingsByDomainUIDParams) ([]MinimumRecordSetFindings, error) {
+	rows, err := q.db.Query(ctx, assessGetMinimumRecordSetFindingsByDomainUID, arg.Uid, arg.TenantID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []MinimumRecordSetFindings{}
+	for rows.Next() {
+		var i MinimumRecordSetFindings
+		if err := rows.Scan(
+			&i.ID,
+			&i.Uid,
+			&i.DomainID,
+			&i.Severity,
+			&i.Status,
+			&i.IssueType,
+			&i.MissingRecordType,
+			&i.Details,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const assessGetSPFFindingByDomainID = `-- name: AssessGetSPFFindingByDomainID :many
 SELECT sf.id, sf.uid, sf.domain_id, sf.txt_record_id, sf.severity, sf.status, sf.issue_type, sf.spf_value, sf.details, sf.created_at, sf.updated_at
 FROM spf_findings sf
@@ -1006,6 +1090,9 @@ open_findings AS (
     UNION ALL
     SELECT domain_id, severity::text FROM caa_compliance_findings
         WHERE status = 'open' AND domain_id = ANY($1::int[])
+    UNION ALL
+    SELECT domain_id, severity::text FROM minimum_record_set_findings
+        WHERE status = 'open' AND domain_id = ANY($1::int[])
 )
 SELECT
     ids.domain_id::int AS domain_id,
@@ -1164,7 +1251,16 @@ FROM (SELECT sf.uid                AS finding_uid,
       FROM caa_compliance_findings cpf
                JOIN domains d ON cpf.domain_id = d.id
       WHERE d.tenant_id = $1
-        AND ($2::bool OR cpf.status = 'open')) f
+        AND ($2::bool OR cpf.status = 'open')
+
+      UNION ALL
+
+      SELECT mrf.uid, d.uid, d.name, 'MIN_RECORDS'::text, mrf.severity, mrf.status,
+             mrf.issue_type, mrf.missing_record_type, mrf.details, NULL::text, mrf.created_at
+      FROM minimum_record_set_findings mrf
+               JOIN domains d ON mrf.domain_id = d.id
+      WHERE d.tenant_id = $1
+        AND ($2::bool OR mrf.status = 'open')) f
 ORDER BY f.domain_name ASC,
          CASE f.severity
              WHEN 'critical' THEN 1
@@ -1407,6 +1503,8 @@ FROM (
         SELECT domain_id, severity::text FROM caa_configuration_findings WHERE status = 'open'
         UNION ALL
         SELECT domain_id, severity::text FROM caa_compliance_findings WHERE status = 'open'
+        UNION ALL
+        SELECT domain_id, severity::text FROM minimum_record_set_findings WHERE status = 'open'
     ) f ON f.domain_id = d.id
     GROUP BY d.tenant_id, d.id
 ) agg

--- a/internal/ui/findings_handlers.go
+++ b/internal/ui/findings_handlers.go
@@ -98,6 +98,7 @@ var findingKindOrder = []string{
 	"DNSSEC",
 	"CAA_CONFIG",
 	"CAA_COMPLIANCE",
+	"MIN_RECORDS",
 }
 
 var findingKindLabels = map[string]string{
@@ -109,6 +110,7 @@ var findingKindLabels = map[string]string{
 	"DNSSEC":         "DNSSEC",
 	"CAA_CONFIG":     "CAA configuration",
 	"CAA_COMPLIANCE": "CAA compliance",
+	"MIN_RECORDS":    "Minimum records",
 }
 
 // kindOptions builds the data-driven type dropdown from the faceted KindCounts.

--- a/sql/queries/assessors.sql
+++ b/sql/queries/assessors.sql
@@ -111,6 +111,29 @@ WHERE d.uid = $1
   AND d.tenant_id = $2
 ORDER BY ccf.severity ASC, ccf.created_at DESC;
 
+-- name: AssessCreateMinimumRecordSetFinding :one
+INSERT INTO minimum_record_set_findings (domain_id,
+                                         severity,
+                                         status,
+                                         issue_type,
+                                         missing_record_type,
+                                         details)
+VALUES ($1, $2, $3, $4, $5, $6)
+ON CONFLICT (domain_id, issue_type)
+    DO UPDATE SET severity            = $2,
+                  status              = $3,
+                  missing_record_type = $5,
+                  details             = $6
+RETURNING (xmax = 0)::boolean AS inserted;
+
+-- name: AssessGetMinimumRecordSetFindingsByDomainUID :many
+SELECT mrf.*
+FROM minimum_record_set_findings mrf
+         JOIN domains d ON mrf.domain_id = d.id
+WHERE d.uid = $1
+  AND d.tenant_id = $2
+ORDER BY mrf.severity ASC, mrf.created_at DESC;
+
 -- name: StoreDanglingCnameFinding :one
 INSERT INTO dangling_cname_findings (domain_id,
                                      severity,
@@ -329,6 +352,9 @@ open_findings AS (
     UNION ALL
     SELECT domain_id, severity::text FROM caa_compliance_findings
         WHERE status = 'open' AND domain_id = ANY(@domain_ids::int[])
+    UNION ALL
+    SELECT domain_id, severity::text FROM minimum_record_set_findings
+        WHERE status = 'open' AND domain_id = ANY(@domain_ids::int[])
 )
 SELECT
     ids.domain_id::int AS domain_id,
@@ -462,7 +488,16 @@ FROM (SELECT sf.uid                AS finding_uid,
       FROM caa_compliance_findings cpf
                JOIN domains d ON cpf.domain_id = d.id
       WHERE d.tenant_id = @tenant_id
-        AND (@include_compliant::bool OR cpf.status = 'open')) f
+        AND (@include_compliant::bool OR cpf.status = 'open')
+
+      UNION ALL
+
+      SELECT mrf.uid, d.uid, d.name, 'MIN_RECORDS'::text, mrf.severity, mrf.status,
+             mrf.issue_type, mrf.missing_record_type, mrf.details, NULL::text, mrf.created_at
+      FROM minimum_record_set_findings mrf
+               JOIN domains d ON mrf.domain_id = d.id
+      WHERE d.tenant_id = @tenant_id
+        AND (@include_compliant::bool OR mrf.status = 'open')) f
 ORDER BY f.domain_name ASC,
          CASE f.severity
              WHEN 'critical' THEN 1
@@ -514,6 +549,8 @@ FROM (
         SELECT domain_id, severity::text FROM caa_configuration_findings WHERE status = 'open'
         UNION ALL
         SELECT domain_id, severity::text FROM caa_compliance_findings WHERE status = 'open'
+        UNION ALL
+        SELECT domain_id, severity::text FROM minimum_record_set_findings WHERE status = 'open'
     ) f ON f.domain_id = d.id
     GROUP BY d.tenant_id, d.id
 ) agg


### PR DESCRIPTION
Closes #63. Part of #61 (Tier 1 quick win).

Wires up the dormant `minimum_record_set_findings` table. Uses records already collected by `ResolveDomainWorker` (A/AAAA/NS/SOA/MX/TXT) — pure analysis apart from a single rate-limited MNAME resolvability lookup via the shared resolver.

## Scope

**Apex-only.** NS and SOA are zone-apex concepts, so the assessor runs solely for `tld` domains and skips subdomains (mirroring the DNSSEC "not applicable" precedent).

## Checks

**Essential records**
- `insufficient_nameservers` — fewer than 2 NS (RFC 2182) — `high`
- `missing_apex_address` — no A and no AAAA at apex — `medium`
- `missing_ipv6` — A present but no AAAA (advisory) — `info`
- `missing_soa` — no SOA at the zone apex — `medium`
- `missing_mx` — no MX/null-MX when email is intended — `low`

**SOA hygiene**
- `soa_timers_out_of_range` — refresh/retry/expire/minimum outside RFC 1912 ranges — `low`
- `soa_serial_format` — serial not in advisory YYYYMMDDnn form — `info`
- `soa_mname_unresolvable` — primary master has no A/AAAA — `medium`
- `soa_rname_malformed` — responsible-party RNAME not well-formed — `low`

## Decisions

- **Email-expected** is inferred from the presence of SPF/DMARC TXT records (clear email intent), keeping the check zero-egress and low-false-positive. An explicit null-MX (RFC 7505) is treated as compliant.
- **MNAME resolvability** is the only outbound check; it goes through the existing fleet rate-limited, cached resolver (one A/AAAA lookup per apex).
- Severity follows the agreed "balanced" profile (resolution/redundancy gaps rank highest, IPv6/serial advisories lowest).

## Notes

- Migration `00025` adds the `UNIQUE (domain_id, issue_type)` constraint the dormant table lacked; findings upsert on conflict and auto-resolve on re-scan.
- `AssessMinimumRecordSet` is enqueued unconditionally from `ResolveDomainWorker`; the apex gate lives inside the assessor.
- Surfaced through the findings API (`kind=MIN_RECORDS`) and browser UI; the `missing_record_type` column is carried into the tenant listing's value field.

Verified: `go test -race ./...` green (686 tests), `task audit` clean, `task ci:all` (Dagger lint+test+build) green.
