### PR TITLE
nameserver configuration & redundancy assessor

### DIFF
--- a/assets/migrations/00027_nameserver_findings_unique.sql
+++ b/assets/migrations/00027_nameserver_findings_unique.sql
@@ -1,0 +1,23 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE ns_configuration_findings
+    ADD CONSTRAINT ns_configuration_findings_domain_ns_issue_key
+        UNIQUE (domain_id, nameserver, issue_type);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE nameserver_redundancy_findings
+    ADD CONSTRAINT nameserver_redundancy_findings_domain_issue_key
+        UNIQUE (domain_id, issue_type);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE ns_configuration_findings
+    DROP CONSTRAINT ns_configuration_findings_domain_ns_issue_key;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE nameserver_redundancy_findings
+    DROP CONSTRAINT nameserver_redundancy_findings_domain_issue_key;
+-- +goose StatementEnd

--- a/internal/assessor/assess_nameserver_config.go
+++ b/internal/assessor/assess_nameserver_config.go
@@ -1,0 +1,292 @@
+package assessor
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/danielmichaels/gecko/internal/observer"
+	"github.com/danielmichaels/gecko/internal/store"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/weppos/publicsuffix-go/publicsuffix"
+)
+
+const (
+	NSInsufficientNameservers = "insufficient_nameservers"
+	NSSameProvider            = "same_provider"
+	NSNoIPv6                  = "no_ipv6"
+	NSNotResolvable           = "ns_not_resolvable"
+	NSIsCNAME                 = "ns_is_cname"
+)
+
+// nsRecommendedCount is RFC 2182's minimum: a zone SHOULD have at least two
+// nameservers, ideally on diverse networks.
+const nsRecommendedCount = 2
+
+// AssessNameserverConfig evaluates a domain's delegated nameserver set for
+// redundancy and per-nameserver hygiene. It reads the already-collected
+// authoritative NS set from ns_records, then actively resolves each nameserver
+// (CNAME/A/AAAA) through the rate-limited resolver to detect missing glue,
+// illegal CNAME aliasing, and IPv6 coverage gaps.
+//
+// Two checks from the original scope are deliberately deferred to follow-ups:
+// parent/child lame-delegation detection (gecko stores only the child's
+// authoritative NS set today, not the parent's delegation), and true ASN/network
+// diversity. This v1 approximates provider diversity by the registrable apex of
+// each nameserver hostname, which catches the common all-NS-at-one-provider case.
+func (a *Assessor) AssessNameserverConfig(ctx context.Context, domainUID string) error {
+	domain, err := a.store.DomainsGetByIdentifier(ctx, store.DomainsGetByIdentifierParams{
+		Uid:      domainUID,
+		TenantID: pgtype.Int4{Int32: a.identity.TenantID, Valid: true},
+	})
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("domain %s not found in database", domainUID)
+		}
+		a.logger.ErrorContext(ctx, "Error looking up domain", "domain", domainUID, "error", err)
+		return err
+	}
+
+	records, err := a.store.RecordsGetNSByDomainID(
+		ctx,
+		pgtype.Int4{Int32: domain.ID, Valid: true},
+	)
+	if err != nil {
+		a.logger.ErrorContext(
+			ctx,
+			"Failed to retrieve NS records",
+			"domain",
+			domain.Uid,
+			"error",
+			err,
+		)
+		return err
+	}
+
+	resolutions := a.resolveNameservers(records)
+	if err := a.assessPerNameserver(ctx, domain.ID, resolutions); err != nil {
+		return err
+	}
+	return a.assessRedundancy(ctx, domain.ID, resolutions)
+}
+
+// nsResolution captures the live resolution state of a single nameserver host.
+type nsResolution struct {
+	record     store.NsRecords
+	hasAddress bool
+	hasIPv6    bool
+	isCNAME    bool
+}
+
+func (a *Assessor) resolveNameservers(records []store.NsRecords) []nsResolution {
+	out := make([]nsResolution, 0, len(records))
+	for _, r := range records {
+		host := strings.TrimSuffix(strings.ToLower(strings.TrimSpace(r.Nameserver)), ".")
+		res := nsResolution{record: r}
+		if cname, ok := a.dnsClient.LookupCNAME(host); ok && len(cname) > 0 {
+			res.isCNAME = true
+		}
+		if v4, ok := a.dnsClient.LookupA(host); ok && len(v4) > 0 {
+			res.hasAddress = true
+		}
+		if v6, ok := a.dnsClient.LookupAAAA(host); ok && len(v6) > 0 {
+			res.hasAddress = true
+			res.hasIPv6 = true
+		}
+		out = append(out, res)
+	}
+	return out
+}
+
+func (a *Assessor) assessPerNameserver(
+	ctx context.Context,
+	domainID int32,
+	resolutions []nsResolution,
+) error {
+	for _, res := range resolutions {
+		cnameStatus := store.FindingStatusResolved
+		cnameDetails := "Nameserver resolves to an address record, not a CNAME"
+		if res.isCNAME {
+			cnameStatus = store.FindingStatusOpen
+			cnameDetails = "Nameserver target is a CNAME, which is illegal for NS records (RFC 2181 §10.3)"
+		}
+		if err := a.createNSConfigFinding(ctx, domainID, res.record, store.FindingSeverityMedium,
+			cnameStatus, NSIsCNAME, cnameDetails); err != nil {
+			return err
+		}
+
+		// A CNAME points somewhere, so it is "illegal" rather than "unresolvable";
+		// only flag not-resolvable when there is neither an address nor a CNAME.
+		resolveStatus := store.FindingStatusResolved
+		resolveDetails := "Nameserver resolves to an A or AAAA address"
+		if !res.hasAddress && !res.isCNAME {
+			resolveStatus = store.FindingStatusOpen
+			resolveDetails = "Nameserver does not resolve to any A or AAAA address (missing glue or lame delegation)"
+		}
+		if err := a.createNSConfigFinding(ctx, domainID, res.record, store.FindingSeverityMedium,
+			resolveStatus, NSNotResolvable, resolveDetails); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (a *Assessor) assessRedundancy(
+	ctx context.Context,
+	domainID int32,
+	resolutions []nsResolution,
+) error {
+	count := int32(len(resolutions))
+
+	insufficientStatus := store.FindingStatusResolved
+	insufficientDetails := fmt.Sprintf(
+		"Domain delegates to %d nameservers (RFC 2182 recommends at least %d)",
+		count, nsRecommendedCount,
+	)
+	if int(count) < nsRecommendedCount {
+		insufficientStatus = store.FindingStatusOpen
+		insufficientDetails = fmt.Sprintf(
+			"Domain delegates to only %d nameserver(s); RFC 2182 recommends at least %d",
+			count, nsRecommendedCount,
+		)
+	}
+	if err := a.createNSRedundancyFinding(ctx, domainID, store.FindingSeverityHigh,
+		insufficientStatus, NSInsufficientNameservers, count, insufficientDetails); err != nil {
+		return err
+	}
+
+	providerStatus := store.FindingStatusResolved
+	providerDetails := "Nameservers are spread across multiple providers"
+	if int(count) >= nsRecommendedCount && distinctProviders(resolutions) <= 1 {
+		providerStatus = store.FindingStatusOpen
+		providerDetails = "All nameservers belong to a single provider; an outage there takes the entire zone offline"
+	}
+	if err := a.createNSRedundancyFinding(ctx, domainID, store.FindingSeverityMedium,
+		providerStatus, NSSameProvider, count, providerDetails); err != nil {
+		return err
+	}
+
+	ipv6Status := store.FindingStatusResolved
+	ipv6Details := "At least one nameserver is reachable over IPv6"
+	if count > 0 && !anyIPv6(resolutions) {
+		ipv6Status = store.FindingStatusOpen
+		ipv6Details = "No nameserver in the set is reachable over IPv6; IPv6-only resolvers cannot reach the zone"
+	}
+	return a.createNSRedundancyFinding(ctx, domainID, store.FindingSeverityLow,
+		ipv6Status, NSNoIPv6, count, ipv6Details)
+}
+
+// distinctProviders counts the unique registrable apexes across the nameserver
+// set, the v1 proxy for provider diversity.
+func distinctProviders(resolutions []nsResolution) int {
+	providers := make(map[string]struct{}, len(resolutions))
+	for _, res := range resolutions {
+		providers[nsProviderApex(res.record.Nameserver)] = struct{}{}
+	}
+	return len(providers)
+}
+
+func anyIPv6(resolutions []nsResolution) bool {
+	for _, res := range resolutions {
+		if res.hasIPv6 {
+			return true
+		}
+	}
+	return false
+}
+
+// nsProviderApex returns the registrable domain (eTLD+1) of a nameserver host,
+// falling back to the bare host when the public-suffix lookup fails.
+func nsProviderApex(host string) string {
+	h := strings.TrimSuffix(strings.ToLower(strings.TrimSpace(host)), ".")
+	apex, err := publicsuffix.Domain(h)
+	if err != nil || apex == "" {
+		return h
+	}
+	return apex
+}
+
+func (a *Assessor) createNSConfigFinding(
+	ctx context.Context,
+	domainID int32,
+	record store.NsRecords,
+	severity store.FindingSeverity,
+	status store.FindingStatus,
+	issueType, details string,
+) error {
+	if _, err := a.store.AssessCreateNSConfigurationFinding(ctx, store.AssessCreateNSConfigurationFindingParams{
+		DomainID:   pgtype.Int4{Int32: domainID, Valid: true},
+		NsRecordID: pgtype.Int4{Int32: record.ID, Valid: true},
+		Severity:   severity,
+		Status:     status,
+		IssueType:  issueType,
+		Nameserver: record.Nameserver,
+		Details:    pgtype.Text{String: details, Valid: details != ""},
+	}); err != nil {
+		a.logger.WarnContext(ctx, "failed to create ns configuration finding",
+			"issue_type", issueType, "nameserver", record.Nameserver, "error", err)
+		return fmt.Errorf(
+			"create ns configuration finding %s/%s: %w",
+			record.Nameserver,
+			issueType,
+			err,
+		)
+	}
+
+	payload := observer.PayloadJSON(map[string]any{
+		"issue_type": issueType,
+		"nameserver": record.Nameserver,
+		"severity":   string(severity),
+		"status":     string(status),
+		"details":    details,
+	})
+	if oErr := observer.New(a.store).RecordFindingChange(
+		ctx, a.identity, observer.EntityNSConfigurationFinding, issueType+"|"+record.Nameserver, payload,
+	); oErr != nil {
+		a.logger.WarnContext(ctx, "failed to emit ns configuration finding observation",
+			"issue_type", issueType, "nameserver", record.Nameserver, "error", oErr)
+	}
+	return nil
+}
+
+func (a *Assessor) createNSRedundancyFinding(
+	ctx context.Context,
+	domainID int32,
+	severity store.FindingSeverity,
+	status store.FindingStatus,
+	issueType string,
+	count int32,
+	details string,
+) error {
+	if _, err := a.store.AssessCreateNameserverRedundancyFinding(ctx, store.AssessCreateNameserverRedundancyFindingParams{
+		DomainID:         pgtype.Int4{Int32: domainID, Valid: true},
+		Severity:         severity,
+		Status:           status,
+		IssueType:        issueType,
+		NameserverCount:  count,
+		RecommendedCount: nsRecommendedCount,
+		Details:          pgtype.Text{String: details, Valid: details != ""},
+	}); err != nil {
+		a.logger.WarnContext(ctx, "failed to create nameserver redundancy finding",
+			"issue_type", issueType, "error", err)
+		return fmt.Errorf("create nameserver redundancy finding %s: %w", issueType, err)
+	}
+
+	payload := observer.PayloadJSON(map[string]any{
+		"issue_type":        issueType,
+		"severity":          string(severity),
+		"status":            string(status),
+		"nameserver_count":  count,
+		"recommended_count": nsRecommendedCount,
+		"details":           details,
+	})
+	if oErr := observer.New(a.store).RecordFindingChange(
+		ctx, a.identity, observer.EntityNameserverRedundancyFinding, issueType, payload,
+	); oErr != nil {
+		a.logger.WarnContext(ctx, "failed to emit nameserver redundancy finding observation",
+			"issue_type", issueType, "error", oErr)
+	}
+	return nil
+}

--- a/internal/assessor/assess_nameserver_config_test.go
+++ b/internal/assessor/assess_nameserver_config_test.go
@@ -1,0 +1,304 @@
+package assessor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/danielmichaels/gecko/internal/dnsclient"
+	"github.com/danielmichaels/gecko/internal/observer"
+	"github.com/danielmichaels/gecko/internal/store"
+	"github.com/danielmichaels/gecko/internal/testhelpers"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/miekg/dns"
+)
+
+func nsConfigByIssue(
+	findings []store.NsConfigurationFindings,
+	nameserver, issueType string,
+) (store.NsConfigurationFindings, bool) {
+	for _, f := range findings {
+		if f.Nameserver == nameserver && f.IssueType == issueType {
+			return f, true
+		}
+	}
+	return store.NsConfigurationFindings{}, false
+}
+
+func nsRedundancyByIssue(
+	findings []store.NameserverRedundancyFindings,
+	issueType string,
+) (store.NameserverRedundancyFindings, bool) {
+	for _, f := range findings {
+		if f.IssueType == issueType {
+			return f, true
+		}
+	}
+	return store.NameserverRedundancyFindings{}, false
+}
+
+func TestAssessNameserverConfig(t *testing.T) {
+	ctx := context.Background()
+	pgContainer, err := testhelpers.CreatePostgresContainer(ctx)
+	if err != nil {
+		t.Fatalf("Failed to create postgres container: %v", err)
+	}
+	defer pgContainer.Close(ctx)
+
+	mockServer, err := testhelpers.NewMockDNSServer()
+	if err != nil {
+		t.Fatalf("Failed to create mock DNS server: %v", err)
+	}
+	if err := mockServer.Start(); err != nil {
+		t.Fatalf("Failed to start mock DNS server: %v", err)
+	}
+	defer func() { _ = mockServer.Stop() }()
+
+	dnsClient := dnsclient.New(
+		dnsclient.WithServers([]string{mockServer.ListenAddr}),
+		dnsclient.WithLogger(testhelpers.TestLogger),
+	)
+
+	newDomain := func(t *testing.T, name string) store.DomainsCreateRow {
+		t.Helper()
+		d, err := pgContainer.Queries.DomainsCreate(ctx, store.DomainsCreateParams{
+			TenantID:   pgtype.Int4{Int32: 1, Valid: true},
+			Name:       name,
+			DomainType: store.DomainTypeTld,
+			Source:     store.DomainSourceUserSupplied,
+			Status:     store.DomainStatusActive,
+		})
+		if err != nil {
+			t.Fatalf("Failed to create domain %s: %v", name, err)
+		}
+		return d
+	}
+
+	seedNS := func(t *testing.T, domainID int32, nameserver string) {
+		t.Helper()
+		if _, err := pgContainer.Queries.RecordsCreateNS(ctx, store.RecordsCreateNSParams{
+			DomainID:   pgtype.Int4{Int32: domainID, Valid: true},
+			Nameserver: nameserver,
+		}); err != nil {
+			t.Fatalf("Failed to seed NS record %s: %v", nameserver, err)
+		}
+	}
+
+	addAddr := func(t *testing.T, host string, rrtype uint16, value string) {
+		t.Helper()
+		if err := mockServer.AddRecord(host, rrtype, 3600, value); err != nil {
+			t.Fatalf("Failed to add %s record for %s: %v", value, host, err)
+		}
+	}
+
+	run := func(t *testing.T, d store.DomainsCreateRow) {
+		t.Helper()
+		ident := observer.DomainIdentity{
+			TenantID:   1,
+			DomainID:   d.ID,
+			DomainUID:  d.Uid,
+			DomainName: d.Name,
+		}
+		a := NewAssessor(Config{
+			Store:     pgContainer.Queries,
+			Logger:    testhelpers.TestLogger,
+			DNSClient: dnsClient,
+			Identity:  ident,
+		})
+		if err := a.AssessNameserverConfig(ctx, d.Uid); err != nil {
+			t.Fatalf("AssessNameserverConfig failed: %v", err)
+		}
+	}
+
+	getConfig := func(t *testing.T, d store.DomainsCreateRow) []store.NsConfigurationFindings {
+		t.Helper()
+		findings, err := pgContainer.Queries.AssessGetNSConfigurationFindingsByDomainUID(
+			ctx,
+			store.AssessGetNSConfigurationFindingsByDomainUIDParams{
+				Uid:      d.Uid,
+				TenantID: pgtype.Int4{Int32: 1, Valid: true},
+			},
+		)
+		if err != nil {
+			t.Fatalf("Failed to get NS configuration findings: %v", err)
+		}
+		return findings
+	}
+
+	getRedundancy := func(t *testing.T, d store.DomainsCreateRow) []store.NameserverRedundancyFindings {
+		t.Helper()
+		findings, err := pgContainer.Queries.AssessGetNameserverRedundancyFindingsByDomainUID(
+			ctx,
+			store.AssessGetNameserverRedundancyFindingsByDomainUIDParams{
+				Uid:      d.Uid,
+				TenantID: pgtype.Int4{Int32: 1, Valid: true},
+			},
+		)
+		if err != nil {
+			t.Fatalf("Failed to get nameserver redundancy findings: %v", err)
+		}
+		return findings
+	}
+
+	t.Run("a single nameserver is a high-severity redundancy gap", func(t *testing.T) {
+		d := newDomain(t, "solo-ns.test")
+		ns := "ns1.solo-provider.com"
+		seedNS(t, d.ID, ns)
+		addAddr(t, ns, dns.TypeA, "192.0.2.10")
+		addAddr(t, ns, dns.TypeAAAA, "2001:db8::10")
+		run(t, d)
+
+		f, ok := nsRedundancyByIssue(getRedundancy(t, d), NSInsufficientNameservers)
+		if !ok {
+			t.Fatalf("expected insufficient_nameservers finding")
+		}
+		if f.Severity != store.FindingSeverityHigh || f.Status != store.FindingStatusOpen {
+			t.Errorf("expected high/open, got %s/%s", f.Severity, f.Status)
+		}
+		if f.NameserverCount != 1 || f.RecommendedCount != 2 {
+			t.Errorf(
+				"expected count 1 / recommended 2, got %d/%d",
+				f.NameserverCount,
+				f.RecommendedCount,
+			)
+		}
+	})
+
+	t.Run(
+		"two nameservers at one provider is a medium single-provider finding",
+		func(t *testing.T) {
+			d := newDomain(t, "single-provider.test")
+			ns1, ns2 := "ns1.oneprovider.com", "ns2.oneprovider.com"
+			seedNS(t, d.ID, ns1)
+			seedNS(t, d.ID, ns2)
+			for _, ns := range []string{ns1, ns2} {
+				addAddr(t, ns, dns.TypeA, "192.0.2.20")
+				addAddr(t, ns, dns.TypeAAAA, "2001:db8::20")
+			}
+			run(t, d)
+
+			red := getRedundancy(t, d)
+			sp, ok := nsRedundancyByIssue(red, NSSameProvider)
+			if !ok {
+				t.Fatalf("expected same_provider finding")
+			}
+			if sp.Severity != store.FindingSeverityMedium || sp.Status != store.FindingStatusOpen {
+				t.Errorf("expected medium/open, got %s/%s", sp.Severity, sp.Status)
+			}
+			if insuff, ok := nsRedundancyByIssue(red, NSInsufficientNameservers); ok {
+				if insuff.Status != store.FindingStatusResolved {
+					t.Errorf("expected insufficient_nameservers resolved, got %s", insuff.Status)
+				}
+			}
+		},
+	)
+
+	t.Run("two diverse healthy nameservers produce no open findings", func(t *testing.T) {
+		d := newDomain(t, "healthy-ns.test")
+		ns1, ns2 := "ns1.alpha-dns.com", "ns2.beta-dns.net"
+		seedNS(t, d.ID, ns1)
+		seedNS(t, d.ID, ns2)
+		addAddr(t, ns1, dns.TypeA, "192.0.2.31")
+		addAddr(t, ns1, dns.TypeAAAA, "2001:db8::31")
+		addAddr(t, ns2, dns.TypeA, "192.0.2.32")
+		addAddr(t, ns2, dns.TypeAAAA, "2001:db8::32")
+		run(t, d)
+
+		for _, f := range getRedundancy(t, d) {
+			if f.Status == store.FindingStatusOpen {
+				t.Errorf("unexpected open redundancy finding %s", f.IssueType)
+			}
+		}
+		for _, f := range getConfig(t, d) {
+			if f.Status == store.FindingStatusOpen {
+				t.Errorf("unexpected open config finding %s/%s", f.Nameserver, f.IssueType)
+			}
+		}
+	})
+
+	t.Run("a nameserver with no address is flagged not-resolvable", func(t *testing.T) {
+		d := newDomain(t, "lame-ns.test")
+		ns1, ns2 := "ns1.resolvable-dns.com", "ns2.broken-dns.net"
+		seedNS(t, d.ID, ns1)
+		seedNS(t, d.ID, ns2)
+		addAddr(t, ns1, dns.TypeA, "192.0.2.41")
+		addAddr(t, ns1, dns.TypeAAAA, "2001:db8::41")
+		// ns2 deliberately has no A/AAAA/CNAME records.
+		run(t, d)
+
+		f, ok := nsConfigByIssue(getConfig(t, d), ns2, NSNotResolvable)
+		if !ok {
+			t.Fatalf("expected ns_not_resolvable finding for %s", ns2)
+		}
+		if f.Severity != store.FindingSeverityMedium || f.Status != store.FindingStatusOpen {
+			t.Errorf("expected medium/open, got %s/%s", f.Severity, f.Status)
+		}
+	})
+
+	t.Run("a nameserver that is a CNAME is illegal", func(t *testing.T) {
+		d := newDomain(t, "cname-ns.test")
+		ns1, ns2 := "ns1.proper-dns.com", "ns2.aliased-dns.org"
+		seedNS(t, d.ID, ns1)
+		seedNS(t, d.ID, ns2)
+		addAddr(t, ns1, dns.TypeA, "192.0.2.51")
+		addAddr(t, ns1, dns.TypeAAAA, "2001:db8::51")
+		addAddr(t, ns2, dns.TypeCNAME, "real-host.example.com")
+		run(t, d)
+
+		cfg := getConfig(t, d)
+		f, ok := nsConfigByIssue(cfg, ns2, NSIsCNAME)
+		if !ok {
+			t.Fatalf("expected ns_is_cname finding for %s", ns2)
+		}
+		if f.Severity != store.FindingSeverityMedium || f.Status != store.FindingStatusOpen {
+			t.Errorf("expected medium/open, got %s/%s", f.Severity, f.Status)
+		}
+		if nr, ok := nsConfigByIssue(cfg, ns2, NSNotResolvable); ok {
+			if nr.Status != store.FindingStatusResolved {
+				t.Errorf(
+					"a CNAME nameserver should not be flagged not-resolvable, got %s",
+					nr.Status,
+				)
+			}
+		}
+	})
+
+	t.Run("a nameserver set without IPv6 is a low redundancy finding", func(t *testing.T) {
+		d := newDomain(t, "no-ipv6-ns.test")
+		ns1, ns2 := "ns1.ipv4only-dns.com", "ns2.ipv4only-dns.net"
+		seedNS(t, d.ID, ns1)
+		seedNS(t, d.ID, ns2)
+		addAddr(t, ns1, dns.TypeA, "192.0.2.61")
+		addAddr(t, ns2, dns.TypeA, "192.0.2.62")
+		run(t, d)
+
+		f, ok := nsRedundancyByIssue(getRedundancy(t, d), NSNoIPv6)
+		if !ok {
+			t.Fatalf("expected no_ipv6 finding")
+		}
+		if f.Severity != store.FindingSeverityLow || f.Status != store.FindingStatusOpen {
+			t.Errorf("expected low/open, got %s/%s", f.Severity, f.Status)
+		}
+	})
+
+	t.Run("re-running does not duplicate findings", func(t *testing.T) {
+		d := newDomain(t, "idempotent-ns.test")
+		ns := "ns1.idem-provider.com"
+		seedNS(t, d.ID, ns)
+		addAddr(t, ns, dns.TypeA, "192.0.2.71")
+		run(t, d)
+		run(t, d)
+
+		var count int
+		for _, f := range getRedundancy(t, d) {
+			if f.IssueType == NSInsufficientNameservers {
+				count++
+			}
+		}
+		if count != 1 {
+			t.Errorf(
+				"expected exactly one insufficient_nameservers finding after re-run, got %d",
+				count,
+			)
+		}
+	})
+}

--- a/internal/jobs/assess_jobs.go
+++ b/internal/jobs/assess_jobs.go
@@ -345,3 +345,50 @@ func (w *AssessMinimumRecordSetWorker) Work(
 	)
 	return nil
 }
+
+type AssessNameserverConfigArgs struct {
+	DomainJobArgs
+}
+
+func (AssessNameserverConfigArgs) InsertOpts() river.InsertOpts {
+	return river.InsertOpts{
+		Queue: queueAssessor,
+	}
+}
+func (AssessNameserverConfigArgs) Kind() string { return "assess_nameserver_config" }
+
+type AssessNameserverConfigWorker struct {
+	river.WorkerDefaults[AssessNameserverConfigArgs]
+	Logger   slog.Logger
+	Store    *store.Queries
+	PgxPool  *pgxpool.Pool
+	Resolver dnsclient.Resolver
+}
+
+func (w *AssessNameserverConfigWorker) Work(
+	ctx context.Context,
+	job *river.Job[AssessNameserverConfigArgs],
+) error {
+	ctx = tracing.WithNewTraceID(ctx, false)
+	start := time.Now()
+	w.Logger.InfoContext(ctx, "assess nameserver config started", "domain", job.Args.DomainUID)
+	a := assessor.NewAssessor(assessor.Config{
+		Logger:    &w.Logger,
+		Store:     w.Store,
+		DNSClient: w.Resolver,
+		Identity:  job.Args.Identity(),
+	})
+	if err := a.AssessNameserverConfig(ctx, job.Args.DomainUID); err != nil {
+		return err
+	}
+
+	w.Logger.InfoContext(
+		ctx,
+		"assess nameserver config complete",
+		"domain",
+		job.Args.DomainUID,
+		"duration",
+		time.Since(start),
+	)
+	return nil
+}

--- a/internal/jobs/enumerate_jobs.go
+++ b/internal/jobs/enumerate_jobs.go
@@ -255,6 +255,14 @@ func (w *ResolveDomainWorker) Work(ctx context.Context, job *river.Job[ResolveDo
 			"domain", job.Args.DomainUID, "error", err)
 	}
 
+	// Nameserver config assessment runs unconditionally: a single nameserver (or
+	// none) is itself a redundancy finding, so it must run regardless of the NS set.
+	if err := enqueueAssessment(ctx, w.PgxPool, &w.Logger, job.Args.DomainUID,
+		AssessNameserverConfigArgs{DomainJobArgs: job.Args.DomainJobArgs}); err != nil {
+		w.Logger.WarnContext(ctx, "failed to queue nameserver config assessment",
+			"domain", job.Args.DomainUID, "error", err)
+	}
+
 	// Email security assessment is data-dependent: enqueue only when TXT records
 	// were discovered (SPF/DKIM/DMARC live in TXT).
 	if len(resolved.TXT.Entries) > 0 {

--- a/internal/jobs/river.go
+++ b/internal/jobs/river.go
@@ -189,6 +189,15 @@ func New(ctx context.Context, cfg Config) (*river.Client[pgx.Tx], error) {
 				Resolver: cfg.Resolver,
 			},
 		)
+		river.AddWorker(
+			rw,
+			&AssessNameserverConfigWorker{
+				Logger:   *cfg.Logger,
+				Store:    cfg.Store,
+				PgxPool:  cfg.PgxPool,
+				Resolver: cfg.Resolver,
+			},
+		)
 		// maintenance
 		river.AddWorker(rw, &PurgeDNSCacheWorker{Logger: *cfg.Logger, Store: cfg.Store})
 		river.AddWorker(rw, &RefreshTenantStatsWorker{Logger: *cfg.Logger, Store: cfg.Store})

--- a/internal/observer/recorder.go
+++ b/internal/observer/recorder.go
@@ -60,6 +60,9 @@ const (
 
 	EntityEmailAuthComplianceFinding = "email_auth_compliance_finding"
 
+	EntityNSConfigurationFinding      = "ns_configuration_finding"
+	EntityNameserverRedundancyFinding = "nameserver_redundancy_finding"
+
 	// EntityDomain is used only on lifecycle NOTIFY signals (create/delete/status),
 	// never stored as an observation — a domain's existence is the projection
 	// itself. It lets the UI refresh on changes that write no observation row.

--- a/internal/server/findings_handlers.go
+++ b/internal/server/findings_handlers.go
@@ -44,7 +44,7 @@ func toFindingItem(f service.FindingView) FindingItem {
 
 type FindingsListInput struct {
 	Severity         string `query:"severity"          example:"crit"  doc:"Filter by tier: crit|high|med|low. Optional." enum:"crit,high,med,low,"`
-	Kind             string `query:"kind"              example:"SPF"   doc:"Filter by type: SPF|DKIM|DMARC|ZONE|CERT|DNSSEC|CAA_CONFIG|CAA_COMPLIANCE|MIN_RECORDS|EMAIL_COMPLIANCE. Optional." enum:"SPF,DKIM,DMARC,ZONE,CERT,DNSSEC,CAA_CONFIG,CAA_COMPLIANCE,MIN_RECORDS,EMAIL_COMPLIANCE,"`
+	Kind             string `query:"kind"              example:"SPF"   doc:"Filter by type: SPF|DKIM|DMARC|ZONE|CERT|DNSSEC|CAA_CONFIG|CAA_COMPLIANCE|MIN_RECORDS|EMAIL_COMPLIANCE|NS_CONFIG|NS_REDUNDANCY. Optional." enum:"SPF,DKIM,DMARC,ZONE,CERT,DNSSEC,CAA_CONFIG,CAA_COMPLIANCE,MIN_RECORDS,EMAIL_COMPLIANCE,NS_CONFIG,NS_REDUNDANCY,"`
 	DomainQuery      string `query:"q"                 example:"acme"  doc:"Case-insensitive domain-name substring. Optional."`
 	IncludeCompliant bool   `query:"include_compliant" example:"false" doc:"Include compliant/closed findings. Optional."`
 	PaginationQuery

--- a/internal/service/findings.go
+++ b/internal/service/findings.go
@@ -211,6 +211,26 @@ func (s *FindingsService) ListByDomain(
 			))
 		}
 	}
+	if nsConfig, err := s.DB.AssessGetNSConfigurationFindingsByDomainUID(ctx, store.AssessGetNSConfigurationFindingsByDomainUIDParams{
+		Uid:      domainUID,
+		TenantID: tenantID,
+	}); err == nil {
+		for _, f := range nsConfig {
+			findings = append(findings, mapStandardFinding(
+				"NS_CONFIG", f.Severity, f.Status, f.IssueType, f.Details,
+			))
+		}
+	}
+	if nsRedundancy, err := s.DB.AssessGetNameserverRedundancyFindingsByDomainUID(ctx, store.AssessGetNameserverRedundancyFindingsByDomainUIDParams{
+		Uid:      domainUID,
+		TenantID: tenantID,
+	}); err == nil {
+		for _, f := range nsRedundancy {
+			findings = append(findings, mapStandardFinding(
+				"NS_REDUNDANCY", f.Severity, f.Status, f.IssueType, f.Details,
+			))
+		}
+	}
 
 	sort.SliceStable(findings, func(i, j int) bool {
 		return severityRank(findings[i].Severity) < severityRank(findings[j].Severity)
@@ -612,6 +632,10 @@ var findingTitles = map[string]string{
 	"caa_required_for_cert":        "Cert-bearing domain has no CAA",
 	"missing_iodef":                "CAA has no iodef reporting endpoint",
 	"insufficient_nameservers":     "Fewer than two nameservers",
+	"same_provider":                "All nameservers use one provider",
+	"no_ipv6":                      "No nameserver reachable over IPv6",
+	"ns_not_resolvable":            "Nameserver does not resolve",
+	"ns_is_cname":                  "Nameserver is a CNAME (illegal)",
 	"missing_apex_address":         "Apex has no A/AAAA record",
 	"missing_ipv6":                 "No IPv6 (AAAA) at apex",
 	"missing_soa":                  "No SOA record at apex",
@@ -663,6 +687,10 @@ var findingFixes = map[string]string{
 	"caa_conflicting_records":      "Remove the no-issuance directive or the conflicting permissive issue entry.",
 	"missing_iodef":                "Add an iodef property, e.g. 0 iodef \"mailto:security@example.com\".",
 	"insufficient_nameservers":     "Publish at least two nameservers on separate networks (RFC 2182).",
+	"same_provider":                "Add nameservers from a second DNS provider so one outage can't take the zone offline.",
+	"no_ipv6":                      "Add AAAA glue for at least one nameserver so IPv6-only resolvers can reach the zone.",
+	"ns_not_resolvable":            "Publish A/AAAA glue for the nameserver, or remove the stale delegation.",
+	"ns_is_cname":                  "Point the NS record at a host with A/AAAA records, not a CNAME (RFC 2181).",
 	"missing_apex_address":         "Publish an A and/or AAAA record at the apex.",
 	"missing_ipv6":                 "Add an AAAA record to make the apex reachable over IPv6.",
 	"missing_soa":                  "Ensure the zone publishes a SOA record at its apex.",

--- a/internal/store/assessors.sql.go
+++ b/internal/store/assessors.sql.go
@@ -391,6 +391,91 @@ func (q *Queries) AssessCreateMinimumRecordSetFinding(ctx context.Context, arg A
 	return inserted, err
 }
 
+const assessCreateNSConfigurationFinding = `-- name: AssessCreateNSConfigurationFinding :one
+INSERT INTO ns_configuration_findings (domain_id,
+                                       ns_record_id,
+                                       severity,
+                                       status,
+                                       issue_type,
+                                       nameserver,
+                                       details)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
+ON CONFLICT (domain_id, nameserver, issue_type)
+    DO UPDATE SET ns_record_id = $2,
+                  severity     = $3,
+                  status       = $4,
+                  details      = $7
+RETURNING (xmax = 0)::boolean AS inserted
+`
+
+type AssessCreateNSConfigurationFindingParams struct {
+	DomainID   pgtype.Int4     `json:"domain_id"`
+	NsRecordID pgtype.Int4     `json:"ns_record_id"`
+	Severity   FindingSeverity `json:"severity"`
+	Status     FindingStatus   `json:"status"`
+	IssueType  string          `json:"issue_type"`
+	Nameserver string          `json:"nameserver"`
+	Details    pgtype.Text     `json:"details"`
+}
+
+func (q *Queries) AssessCreateNSConfigurationFinding(ctx context.Context, arg AssessCreateNSConfigurationFindingParams) (bool, error) {
+	row := q.db.QueryRow(ctx, assessCreateNSConfigurationFinding,
+		arg.DomainID,
+		arg.NsRecordID,
+		arg.Severity,
+		arg.Status,
+		arg.IssueType,
+		arg.Nameserver,
+		arg.Details,
+	)
+	var inserted bool
+	err := row.Scan(&inserted)
+	return inserted, err
+}
+
+const assessCreateNameserverRedundancyFinding = `-- name: AssessCreateNameserverRedundancyFinding :one
+INSERT INTO nameserver_redundancy_findings (domain_id,
+                                            severity,
+                                            status,
+                                            issue_type,
+                                            nameserver_count,
+                                            recommended_count,
+                                            details)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
+ON CONFLICT (domain_id, issue_type)
+    DO UPDATE SET severity          = $2,
+                  status            = $3,
+                  nameserver_count  = $5,
+                  recommended_count = $6,
+                  details           = $7
+RETURNING (xmax = 0)::boolean AS inserted
+`
+
+type AssessCreateNameserverRedundancyFindingParams struct {
+	DomainID         pgtype.Int4     `json:"domain_id"`
+	Severity         FindingSeverity `json:"severity"`
+	Status           FindingStatus   `json:"status"`
+	IssueType        string          `json:"issue_type"`
+	NameserverCount  int32           `json:"nameserver_count"`
+	RecommendedCount int32           `json:"recommended_count"`
+	Details          pgtype.Text     `json:"details"`
+}
+
+func (q *Queries) AssessCreateNameserverRedundancyFinding(ctx context.Context, arg AssessCreateNameserverRedundancyFindingParams) (bool, error) {
+	row := q.db.QueryRow(ctx, assessCreateNameserverRedundancyFinding,
+		arg.DomainID,
+		arg.Severity,
+		arg.Status,
+		arg.IssueType,
+		arg.NameserverCount,
+		arg.RecommendedCount,
+		arg.Details,
+	)
+	var inserted bool
+	err := row.Scan(&inserted)
+	return inserted, err
+}
+
 const assessCreateSPFFinding = `-- name: AssessCreateSPFFinding :one
 INSERT INTO spf_findings (domain_id,
                           txt_record_id,
@@ -974,6 +1059,98 @@ func (q *Queries) AssessGetMinimumRecordSetFindingsByDomainUID(ctx context.Conte
 	return items, nil
 }
 
+const assessGetNSConfigurationFindingsByDomainUID = `-- name: AssessGetNSConfigurationFindingsByDomainUID :many
+SELECT ncf.id, ncf.uid, ncf.domain_id, ncf.ns_record_id, ncf.severity, ncf.status, ncf.issue_type, ncf.nameserver, ncf.details, ncf.created_at, ncf.updated_at
+FROM ns_configuration_findings ncf
+         JOIN domains d ON ncf.domain_id = d.id
+WHERE d.uid = $1
+  AND d.tenant_id = $2
+ORDER BY ncf.severity ASC, ncf.created_at DESC
+`
+
+type AssessGetNSConfigurationFindingsByDomainUIDParams struct {
+	Uid      string      `json:"uid"`
+	TenantID pgtype.Int4 `json:"tenant_id"`
+}
+
+func (q *Queries) AssessGetNSConfigurationFindingsByDomainUID(ctx context.Context, arg AssessGetNSConfigurationFindingsByDomainUIDParams) ([]NsConfigurationFindings, error) {
+	rows, err := q.db.Query(ctx, assessGetNSConfigurationFindingsByDomainUID, arg.Uid, arg.TenantID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []NsConfigurationFindings{}
+	for rows.Next() {
+		var i NsConfigurationFindings
+		if err := rows.Scan(
+			&i.ID,
+			&i.Uid,
+			&i.DomainID,
+			&i.NsRecordID,
+			&i.Severity,
+			&i.Status,
+			&i.IssueType,
+			&i.Nameserver,
+			&i.Details,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const assessGetNameserverRedundancyFindingsByDomainUID = `-- name: AssessGetNameserverRedundancyFindingsByDomainUID :many
+SELECT nrf.id, nrf.uid, nrf.domain_id, nrf.severity, nrf.status, nrf.issue_type, nrf.nameserver_count, nrf.recommended_count, nrf.details, nrf.created_at, nrf.updated_at
+FROM nameserver_redundancy_findings nrf
+         JOIN domains d ON nrf.domain_id = d.id
+WHERE d.uid = $1
+  AND d.tenant_id = $2
+ORDER BY nrf.severity ASC, nrf.created_at DESC
+`
+
+type AssessGetNameserverRedundancyFindingsByDomainUIDParams struct {
+	Uid      string      `json:"uid"`
+	TenantID pgtype.Int4 `json:"tenant_id"`
+}
+
+func (q *Queries) AssessGetNameserverRedundancyFindingsByDomainUID(ctx context.Context, arg AssessGetNameserverRedundancyFindingsByDomainUIDParams) ([]NameserverRedundancyFindings, error) {
+	rows, err := q.db.Query(ctx, assessGetNameserverRedundancyFindingsByDomainUID, arg.Uid, arg.TenantID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []NameserverRedundancyFindings{}
+	for rows.Next() {
+		var i NameserverRedundancyFindings
+		if err := rows.Scan(
+			&i.ID,
+			&i.Uid,
+			&i.DomainID,
+			&i.Severity,
+			&i.Status,
+			&i.IssueType,
+			&i.NameserverCount,
+			&i.RecommendedCount,
+			&i.Details,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const assessGetSPFFindingByDomainID = `-- name: AssessGetSPFFindingByDomainID :many
 SELECT sf.id, sf.uid, sf.domain_id, sf.txt_record_id, sf.severity, sf.status, sf.issue_type, sf.spf_value, sf.details, sf.created_at, sf.updated_at
 FROM spf_findings sf
@@ -1189,6 +1366,12 @@ open_findings AS (
     UNION ALL
     SELECT domain_id, severity::text FROM email_auth_compliance_findings
         WHERE status = 'open' AND domain_id = ANY($1::int[])
+    UNION ALL
+    SELECT domain_id, severity::text FROM ns_configuration_findings
+        WHERE status = 'open' AND domain_id = ANY($1::int[])
+    UNION ALL
+    SELECT domain_id, severity::text FROM nameserver_redundancy_findings
+        WHERE status = 'open' AND domain_id = ANY($1::int[])
 )
 SELECT
     ids.domain_id::int AS domain_id,
@@ -1365,7 +1548,25 @@ FROM (SELECT sf.uid                AS finding_uid,
       FROM email_auth_compliance_findings eacf
                JOIN domains d ON eacf.domain_id = d.id
       WHERE d.tenant_id = $1
-        AND ($2::bool OR eacf.status = 'open')) f
+        AND ($2::bool OR eacf.status = 'open')
+
+      UNION ALL
+
+      SELECT ncf.uid, d.uid, d.name, 'NS_CONFIG'::text, ncf.severity, ncf.status,
+             ncf.issue_type, ncf.nameserver, ncf.details, NULL::text, ncf.created_at
+      FROM ns_configuration_findings ncf
+               JOIN domains d ON ncf.domain_id = d.id
+      WHERE d.tenant_id = $1
+        AND ($2::bool OR ncf.status = 'open')
+
+      UNION ALL
+
+      SELECT nrf.uid, d.uid, d.name, 'NS_REDUNDANCY'::text, nrf.severity, nrf.status,
+             nrf.issue_type, nrf.nameserver_count::text, nrf.details, NULL::text, nrf.created_at
+      FROM nameserver_redundancy_findings nrf
+               JOIN domains d ON nrf.domain_id = d.id
+      WHERE d.tenant_id = $1
+        AND ($2::bool OR nrf.status = 'open')) f
 ORDER BY f.domain_name ASC,
          CASE f.severity
              WHEN 'critical' THEN 1
@@ -1612,6 +1813,10 @@ FROM (
         SELECT domain_id, severity::text FROM minimum_record_set_findings WHERE status = 'open'
         UNION ALL
         SELECT domain_id, severity::text FROM email_auth_compliance_findings WHERE status = 'open'
+        UNION ALL
+        SELECT domain_id, severity::text FROM ns_configuration_findings WHERE status = 'open'
+        UNION ALL
+        SELECT domain_id, severity::text FROM nameserver_redundancy_findings WHERE status = 'open'
     ) f ON f.domain_id = d.id
     GROUP BY d.tenant_id, d.id
 ) agg

--- a/internal/ui/findings_handlers.go
+++ b/internal/ui/findings_handlers.go
@@ -100,6 +100,8 @@ var findingKindOrder = []string{
 	"CAA_COMPLIANCE",
 	"MIN_RECORDS",
 	"EMAIL_COMPLIANCE",
+	"NS_CONFIG",
+	"NS_REDUNDANCY",
 }
 
 var findingKindLabels = map[string]string{
@@ -113,6 +115,8 @@ var findingKindLabels = map[string]string{
 	"CAA_COMPLIANCE":   "CAA compliance",
 	"MIN_RECORDS":      "Minimum records",
 	"EMAIL_COMPLIANCE": "Email compliance",
+	"NS_CONFIG":        "Nameserver configuration",
+	"NS_REDUNDANCY":    "Nameserver redundancy",
 }
 
 // kindOptions builds the data-driven type dropdown from the faceted KindCounts.

--- a/sql/queries/assessors.sql
+++ b/sql/queries/assessors.sql
@@ -160,6 +160,55 @@ WHERE d.uid = $1
   AND d.tenant_id = $2
 ORDER BY eacf.severity ASC, eacf.created_at DESC;
 
+-- name: AssessCreateNSConfigurationFinding :one
+INSERT INTO ns_configuration_findings (domain_id,
+                                       ns_record_id,
+                                       severity,
+                                       status,
+                                       issue_type,
+                                       nameserver,
+                                       details)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
+ON CONFLICT (domain_id, nameserver, issue_type)
+    DO UPDATE SET ns_record_id = $2,
+                  severity     = $3,
+                  status       = $4,
+                  details      = $7
+RETURNING (xmax = 0)::boolean AS inserted;
+
+-- name: AssessGetNSConfigurationFindingsByDomainUID :many
+SELECT ncf.*
+FROM ns_configuration_findings ncf
+         JOIN domains d ON ncf.domain_id = d.id
+WHERE d.uid = $1
+  AND d.tenant_id = $2
+ORDER BY ncf.severity ASC, ncf.created_at DESC;
+
+-- name: AssessCreateNameserverRedundancyFinding :one
+INSERT INTO nameserver_redundancy_findings (domain_id,
+                                            severity,
+                                            status,
+                                            issue_type,
+                                            nameserver_count,
+                                            recommended_count,
+                                            details)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
+ON CONFLICT (domain_id, issue_type)
+    DO UPDATE SET severity          = $2,
+                  status            = $3,
+                  nameserver_count  = $5,
+                  recommended_count = $6,
+                  details           = $7
+RETURNING (xmax = 0)::boolean AS inserted;
+
+-- name: AssessGetNameserverRedundancyFindingsByDomainUID :many
+SELECT nrf.*
+FROM nameserver_redundancy_findings nrf
+         JOIN domains d ON nrf.domain_id = d.id
+WHERE d.uid = $1
+  AND d.tenant_id = $2
+ORDER BY nrf.severity ASC, nrf.created_at DESC;
+
 -- name: StoreDanglingCnameFinding :one
 INSERT INTO dangling_cname_findings (domain_id,
                                      severity,
@@ -384,6 +433,12 @@ open_findings AS (
     UNION ALL
     SELECT domain_id, severity::text FROM email_auth_compliance_findings
         WHERE status = 'open' AND domain_id = ANY(@domain_ids::int[])
+    UNION ALL
+    SELECT domain_id, severity::text FROM ns_configuration_findings
+        WHERE status = 'open' AND domain_id = ANY(@domain_ids::int[])
+    UNION ALL
+    SELECT domain_id, severity::text FROM nameserver_redundancy_findings
+        WHERE status = 'open' AND domain_id = ANY(@domain_ids::int[])
 )
 SELECT
     ids.domain_id::int AS domain_id,
@@ -535,7 +590,25 @@ FROM (SELECT sf.uid                AS finding_uid,
       FROM email_auth_compliance_findings eacf
                JOIN domains d ON eacf.domain_id = d.id
       WHERE d.tenant_id = @tenant_id
-        AND (@include_compliant::bool OR eacf.status = 'open')) f
+        AND (@include_compliant::bool OR eacf.status = 'open')
+
+      UNION ALL
+
+      SELECT ncf.uid, d.uid, d.name, 'NS_CONFIG'::text, ncf.severity, ncf.status,
+             ncf.issue_type, ncf.nameserver, ncf.details, NULL::text, ncf.created_at
+      FROM ns_configuration_findings ncf
+               JOIN domains d ON ncf.domain_id = d.id
+      WHERE d.tenant_id = @tenant_id
+        AND (@include_compliant::bool OR ncf.status = 'open')
+
+      UNION ALL
+
+      SELECT nrf.uid, d.uid, d.name, 'NS_REDUNDANCY'::text, nrf.severity, nrf.status,
+             nrf.issue_type, nrf.nameserver_count::text, nrf.details, NULL::text, nrf.created_at
+      FROM nameserver_redundancy_findings nrf
+               JOIN domains d ON nrf.domain_id = d.id
+      WHERE d.tenant_id = @tenant_id
+        AND (@include_compliant::bool OR nrf.status = 'open')) f
 ORDER BY f.domain_name ASC,
          CASE f.severity
              WHEN 'critical' THEN 1
@@ -591,6 +664,10 @@ FROM (
         SELECT domain_id, severity::text FROM minimum_record_set_findings WHERE status = 'open'
         UNION ALL
         SELECT domain_id, severity::text FROM email_auth_compliance_findings WHERE status = 'open'
+        UNION ALL
+        SELECT domain_id, severity::text FROM ns_configuration_findings WHERE status = 'open'
+        UNION ALL
+        SELECT domain_id, severity::text FROM nameserver_redundancy_findings WHERE status = 'open'
     ) f ON f.domain_id = d.id
     GROUP BY d.tenant_id, d.id
 ) agg


### PR DESCRIPTION
Wires up the dormant `ns_configuration_findings` and `nameserver_redundancy_findings` tables (EPIC #61) — the first assessor in this batch that does active per-nameserver DNS resolution.

## Findings

**Redundancy (domain-level)**

| issue_type | meaning | severity |
|---|---|---|
| `insufficient_nameservers` | fewer than 2 NS (RFC 2182) | high |
| `same_provider` | all NS share one registrable apex | medium |
| `no_ipv6` | no NS in the set has an AAAA | low |

**Configuration (per-nameserver)**

| issue_type | meaning | severity |
|---|---|---|
| `ns_not_resolvable` | NS has no A/AAAA and is not a CNAME | medium |
| `ns_is_cname` | NS target is a CNAME (RFC 2181 §10.3) | medium |

## Notes

- Reads the collected NS set from `ns_records`, then resolves each nameserver (CNAME/A/AAAA) through the rate-limited `dnsclient` — bounded fan-out, typically 2–6 lookups per domain.
- Idempotent upserts via new UNIQUE constraints (migration `00027`); every check is re-run each scan, so fixed conditions auto-resolve rather than duplicating rows.
- Enqueued unconditionally from `ResolveDomainWorker` (a single/zero nameserver is itself a finding); surfaced as `NS_CONFIG` / `NS_REDUNDANCY` in the findings API and browser UI.

## Deferred (scope notes)

- **True ASN/network diversity** (`same_network`) — v1 approximates provider diversity by the NS-hostname registrable apex (zero egress).
- **Parent/child NS consistency** (lame delegation) — needs a non-recursive parent-zone delegation query the resolver doesn't expose yet; gecko stores only the child/authoritative NS set today.

Closes #64
