### PR TITLE
nameserver reachability & DNS health assessor 

### DIFF
--- a/assets/migrations/00028_ns_health_findings_unique.sql
+++ b/assets/migrations/00028_ns_health_findings_unique.sql
@@ -1,0 +1,34 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE nameserver_reachability_findings
+    ADD CONSTRAINT nameserver_reachability_findings_domain_ns_issue_key
+        UNIQUE (domain_id, nameserver, issue_type);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE dns_resolution_latency_findings
+    ADD CONSTRAINT dns_resolution_latency_findings_domain_resolver_type_key
+        UNIQUE (domain_id, resolver, record_type);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE dns_resolution_consistency_findings
+    ADD CONSTRAINT dns_resolution_consistency_findings_domain_type_key
+        UNIQUE (domain_id, record_type);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE nameserver_reachability_findings
+    DROP CONSTRAINT nameserver_reachability_findings_domain_ns_issue_key;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE dns_resolution_latency_findings
+    DROP CONSTRAINT dns_resolution_latency_findings_domain_resolver_type_key;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE dns_resolution_consistency_findings
+    DROP CONSTRAINT dns_resolution_consistency_findings_domain_type_key;
+-- +goose StatementEnd

--- a/internal/assessor/assess_nameserver_health.go
+++ b/internal/assessor/assess_nameserver_health.go
@@ -1,0 +1,372 @@
+package assessor
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/danielmichaels/gecko/internal/dnsclient"
+	"github.com/danielmichaels/gecko/internal/observer"
+	"github.com/danielmichaels/gecko/internal/store"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/miekg/dns"
+)
+
+const (
+	NSUnreachable      = "unreachable"
+	NSNoTCPSupport     = "no_tcp_support"
+	NSNoEDNSSupport    = "no_edns_support"
+	NSHighLatency      = "high_latency"
+	NSResolverMismatch = "resolver_mismatch"
+)
+
+// nsHealthRecordType is the record probed at every authoritative nameserver. The
+// zone apex SOA is the canonical liveness + sync signal: its serial reveals
+// whether secondaries have transferred the latest zone.
+const nsHealthRecordType = "SOA"
+
+// Latency tiers (Balanced preset) for an authoritative nameserver's response
+// time, in milliseconds. Below the info threshold is recorded as resolved.
+const (
+	nsLatencyInfoMs   = 150
+	nsLatencyLowMs    = 400
+	nsLatencyMediumMs = 900
+)
+
+// NameserverProber probes a specific authoritative nameserver directly. The
+// production implementation is *dnsclient.DNSClient; tests inject a fake.
+type NameserverProber interface {
+	ProbeNameserver(server, name string, qtype uint16) dnsclient.NSProbeResult
+}
+
+// nsAnswer is one reachable nameserver's apex-SOA answer, used to compare zone
+// state across the authoritative set.
+type nsAnswer struct {
+	nameserver string
+	serial     string
+}
+
+// AssessNameserverHealth probes each authoritative nameserver directly for the
+// zone apex SOA and records reachability (UDP), TCP/EDNS0 support, response
+// latency, and cross-nameserver answer consistency.
+//
+// The consistency check deliberately omits cross-scan dampening for now: DNS
+// nameservers legitimately disagree during propagation, so divergence is flagged
+// only at low severity with a "may be transient" note. Requiring divergence to
+// persist across N scans needs cross-scan state that does not exist yet and is a
+// tracked follow-up.
+func (a *Assessor) AssessNameserverHealth(ctx context.Context, domainUID string) error {
+	domain, err := a.store.DomainsGetByIdentifier(ctx, store.DomainsGetByIdentifierParams{
+		Uid:      domainUID,
+		TenantID: pgtype.Int4{Int32: a.identity.TenantID, Valid: true},
+	})
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("domain %s not found in database", domainUID)
+		}
+		a.logger.ErrorContext(ctx, "Error looking up domain", "domain", domainUID, "error", err)
+		return err
+	}
+
+	if a.nsProber == nil {
+		a.logger.WarnContext(ctx, "nameserver health assessment skipped: no prober configured",
+			"domain", domain.Uid)
+		return nil
+	}
+
+	records, err := a.store.RecordsGetNSByDomainID(
+		ctx,
+		pgtype.Int4{Int32: domain.ID, Valid: true},
+	)
+	if err != nil {
+		a.logger.ErrorContext(
+			ctx,
+			"Failed to retrieve NS records",
+			"domain",
+			domain.Uid,
+			"error",
+			err,
+		)
+		return err
+	}
+
+	var reachable []nsAnswer
+
+	for _, r := range records {
+		host := strings.TrimSuffix(strings.ToLower(strings.TrimSpace(r.Nameserver)), ".")
+		probe := a.nsProber.ProbeNameserver(net.JoinHostPort(host, "53"), domain.Name, dns.TypeSOA)
+
+		if err := a.recordReachability(ctx, domain.ID, r, probe); err != nil {
+			return err
+		}
+		if !probe.Reachable {
+			continue
+		}
+		if err := a.recordLatency(ctx, domain.ID, r.Nameserver, probe.RTT); err != nil {
+			return err
+		}
+		if serial := strings.Join(probe.Answers, " "); serial != "" {
+			reachable = append(reachable, nsAnswer{nameserver: r.Nameserver, serial: serial})
+		}
+	}
+
+	return a.recordConsistency(ctx, domain.ID, reachable)
+}
+
+func (a *Assessor) recordReachability(
+	ctx context.Context,
+	domainID int32,
+	record store.NsRecords,
+	probe dnsclient.NSProbeResult,
+) error {
+	rtt := pgtype.Int4{}
+	if probe.Reachable {
+		rtt = pgtype.Int4{Int32: int32(probe.RTT.Milliseconds()), Valid: true}
+	}
+
+	reachStatus := store.FindingStatusResolved
+	reachDetails := "Nameserver answered a direct UDP query"
+	if !probe.Reachable {
+		reachStatus = store.FindingStatusOpen
+		reachDetails = "Nameserver did not answer a direct UDP query (unreachable or timing out)"
+	}
+	if err := a.createReachabilityFinding(ctx, domainID, record, store.FindingSeverityHigh,
+		reachStatus, NSUnreachable, rtt, reachDetails); err != nil {
+		return err
+	}
+
+	// TCP/EDNS are only meaningful when the server answers at all; for an
+	// unreachable server they are recorded resolved so they do not double-count.
+	tcpStatus := store.FindingStatusResolved
+	tcpDetails := "Nameserver answers over TCP"
+	if probe.Reachable && !probe.TCPOK {
+		tcpStatus = store.FindingStatusOpen
+		tcpDetails = "Nameserver does not answer over TCP, which is required for large responses and DNSSEC"
+	}
+	if err := a.createReachabilityFinding(ctx, domainID, record, store.FindingSeverityMedium,
+		tcpStatus, NSNoTCPSupport, rtt, tcpDetails); err != nil {
+		return err
+	}
+
+	ednsStatus := store.FindingStatusResolved
+	ednsDetails := "Nameserver supports EDNS0"
+	if probe.Reachable && !probe.HasEDNS {
+		ednsStatus = store.FindingStatusOpen
+		ednsDetails = "Nameserver does not support EDNS0, limiting modern DNS features and UDP payload size"
+	}
+	return a.createReachabilityFinding(ctx, domainID, record, store.FindingSeverityInfo,
+		ednsStatus, NSNoEDNSSupport, rtt, ednsDetails)
+}
+
+func (a *Assessor) recordLatency(
+	ctx context.Context,
+	domainID int32,
+	nameserver string,
+	rtt time.Duration,
+) error {
+	ms := int32(rtt.Milliseconds())
+
+	severity := store.FindingSeverityInfo
+	status := store.FindingStatusOpen
+	threshold := int32(nsLatencyInfoMs)
+	switch {
+	case ms >= nsLatencyMediumMs:
+		severity, threshold = store.FindingSeverityMedium, nsLatencyMediumMs
+	case ms >= nsLatencyLowMs:
+		severity, threshold = store.FindingSeverityLow, nsLatencyLowMs
+	case ms >= nsLatencyInfoMs:
+		severity, threshold = store.FindingSeverityInfo, nsLatencyInfoMs
+	default:
+		status = store.FindingStatusResolved
+	}
+
+	details := fmt.Sprintf("Nameserver responded in %dms", ms)
+	if status == store.FindingStatusOpen {
+		details = fmt.Sprintf("Nameserver responded in %dms (exceeds %dms)", ms, threshold)
+	}
+
+	return a.createLatencyFinding(
+		ctx,
+		domainID,
+		nameserver,
+		severity,
+		status,
+		ms,
+		threshold,
+		details,
+	)
+}
+
+func (a *Assessor) recordConsistency(
+	ctx context.Context,
+	domainID int32,
+	answers []nsAnswer,
+) error {
+	if len(answers) == 0 {
+		return nil
+	}
+
+	var divergentNS, divergentSerial string
+	for _, ans := range answers[1:] {
+		if ans.serial != answers[0].serial {
+			divergentNS, divergentSerial = ans.nameserver, ans.serial
+			break
+		}
+	}
+
+	if divergentNS == "" {
+		return a.createConsistencyFinding(ctx, domainID, store.FindingSeverityLow,
+			store.FindingStatusResolved, answers[0].nameserver, answers[0].serial,
+			answers[len(answers)-1].nameserver, answers[len(answers)-1].serial,
+			"All authoritative nameservers agree on the apex SOA")
+	}
+
+	details := fmt.Sprintf(
+		"Authoritative nameservers return divergent apex SOA records (may be transient propagation): %s",
+		summarizeSerials(answers),
+	)
+	return a.createConsistencyFinding(ctx, domainID, store.FindingSeverityLow,
+		store.FindingStatusOpen, answers[0].nameserver, answers[0].serial,
+		divergentNS, divergentSerial, details)
+}
+
+func summarizeSerials(answers []nsAnswer) string {
+	parts := make([]string, 0, len(answers))
+	for _, a := range answers {
+		parts = append(parts, fmt.Sprintf("%s=%q", a.nameserver, a.serial))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func (a *Assessor) createReachabilityFinding(
+	ctx context.Context,
+	domainID int32,
+	record store.NsRecords,
+	severity store.FindingSeverity,
+	status store.FindingStatus,
+	issueType string,
+	responseMs pgtype.Int4,
+	details string,
+) error {
+	if _, err := a.store.AssessCreateNameserverReachabilityFinding(ctx, store.AssessCreateNameserverReachabilityFindingParams{
+		DomainID:       pgtype.Int4{Int32: domainID, Valid: true},
+		NsRecordID:     pgtype.Int4{Int32: record.ID, Valid: true},
+		Severity:       severity,
+		Status:         status,
+		Nameserver:     record.Nameserver,
+		IssueType:      issueType,
+		ResponseTimeMs: responseMs,
+		Details:        pgtype.Text{String: details, Valid: details != ""},
+	}); err != nil {
+		a.logger.WarnContext(ctx, "failed to create nameserver reachability finding",
+			"issue_type", issueType, "nameserver", record.Nameserver, "error", err)
+		return fmt.Errorf(
+			"create nameserver reachability finding %s/%s: %w",
+			record.Nameserver,
+			issueType,
+			err,
+		)
+	}
+	a.emitFindingObservation(
+		ctx,
+		observer.EntityNameserverReachabilityFinding,
+		issueType+"|"+record.Nameserver,
+		map[string]any{
+			"issue_type": issueType, "nameserver": record.Nameserver,
+			"severity": string(severity), "status": string(status), "details": details,
+		},
+	)
+	return nil
+}
+
+func (a *Assessor) createLatencyFinding(
+	ctx context.Context,
+	domainID int32,
+	nameserver string,
+	severity store.FindingSeverity,
+	status store.FindingStatus,
+	latencyMs, thresholdMs int32,
+	details string,
+) error {
+	if _, err := a.store.AssessCreateDNSResolutionLatencyFinding(ctx, store.AssessCreateDNSResolutionLatencyFindingParams{
+		DomainID:    pgtype.Int4{Int32: domainID, Valid: true},
+		Severity:    severity,
+		Status:      status,
+		RecordType:  nsHealthRecordType,
+		Resolver:    nameserver,
+		LatencyMs:   latencyMs,
+		ThresholdMs: thresholdMs,
+		Details:     pgtype.Text{String: details, Valid: details != ""},
+	}); err != nil {
+		a.logger.WarnContext(ctx, "failed to create dns resolution latency finding",
+			"nameserver", nameserver, "error", err)
+		return fmt.Errorf("create dns resolution latency finding %s: %w", nameserver, err)
+	}
+	a.emitFindingObservation(
+		ctx,
+		observer.EntityDNSResolutionLatencyFinding,
+		NSHighLatency+"|"+nameserver,
+		map[string]any{
+			"issue_type": NSHighLatency, "resolver": nameserver, "record_type": nsHealthRecordType,
+			"latency_ms": latencyMs, "threshold_ms": thresholdMs,
+			"severity": string(severity), "status": string(status), "details": details,
+		},
+	)
+	return nil
+}
+
+func (a *Assessor) createConsistencyFinding(
+	ctx context.Context,
+	domainID int32,
+	severity store.FindingSeverity,
+	status store.FindingStatus,
+	resolver1, result1, resolver2, result2, details string,
+) error {
+	if _, err := a.store.AssessCreateDNSResolutionConsistencyFinding(ctx, store.AssessCreateDNSResolutionConsistencyFindingParams{
+		DomainID:        pgtype.Int4{Int32: domainID, Valid: true},
+		Severity:        severity,
+		Status:          status,
+		RecordType:      nsHealthRecordType,
+		Resolver1:       resolver1,
+		Resolver1Result: pgtype.Text{String: result1, Valid: result1 != ""},
+		Resolver2:       resolver2,
+		Resolver2Result: pgtype.Text{String: result2, Valid: result2 != ""},
+		Details:         pgtype.Text{String: details, Valid: details != ""},
+	}); err != nil {
+		a.logger.WarnContext(ctx, "failed to create dns resolution consistency finding",
+			"record_type", nsHealthRecordType, "error", err)
+		return fmt.Errorf(
+			"create dns resolution consistency finding %s: %w",
+			nsHealthRecordType,
+			err,
+		)
+	}
+	a.emitFindingObservation(
+		ctx,
+		observer.EntityDNSResolutionConsistencyFinding,
+		NSResolverMismatch+"|"+nsHealthRecordType,
+		map[string]any{
+			"issue_type": NSResolverMismatch, "record_type": nsHealthRecordType,
+			"resolver1": resolver1, "resolver2": resolver2,
+			"severity": string(severity), "status": string(status), "details": details,
+		},
+	)
+	return nil
+}
+
+func (a *Assessor) emitFindingObservation(
+	ctx context.Context,
+	entityType, entityKey string,
+	payload map[string]any,
+) {
+	if oErr := observer.New(a.store).RecordFindingChange(
+		ctx, a.identity, entityType, entityKey, observer.PayloadJSON(payload),
+	); oErr != nil {
+		a.logger.WarnContext(ctx, "failed to emit finding observation",
+			"entity_type", entityType, "entity_key", entityKey, "error", oErr)
+	}
+}

--- a/internal/assessor/assess_nameserver_health_test.go
+++ b/internal/assessor/assess_nameserver_health_test.go
@@ -1,0 +1,272 @@
+package assessor
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/danielmichaels/gecko/internal/dnsclient"
+	"github.com/danielmichaels/gecko/internal/observer"
+	"github.com/danielmichaels/gecko/internal/store"
+	"github.com/danielmichaels/gecko/internal/testhelpers"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// fakeNSProber returns canned probe results keyed by server address ("host:53"),
+// so the nameserver-health assessor can be exercised without any network.
+type fakeNSProber struct {
+	results map[string]dnsclient.NSProbeResult
+}
+
+func (f *fakeNSProber) ProbeNameserver(
+	server, name string,
+	qtype uint16,
+) dnsclient.NSProbeResult {
+	return f.results[server]
+}
+
+func TestAssessNameserverHealth(t *testing.T) {
+	ctx := context.Background()
+	pgContainer, err := testhelpers.CreatePostgresContainer(ctx)
+	if err != nil {
+		t.Fatalf("Failed to create postgres container: %v", err)
+	}
+	defer pgContainer.Close(ctx)
+
+	prober := &fakeNSProber{results: map[string]dnsclient.NSProbeResult{}}
+
+	newDomain := func(t *testing.T, name string) store.DomainsCreateRow {
+		t.Helper()
+		d, err := pgContainer.Queries.DomainsCreate(ctx, store.DomainsCreateParams{
+			TenantID:   pgtype.Int4{Int32: 1, Valid: true},
+			Name:       name,
+			DomainType: store.DomainTypeTld,
+			Source:     store.DomainSourceUserSupplied,
+			Status:     store.DomainStatusActive,
+		})
+		if err != nil {
+			t.Fatalf("Failed to create domain %s: %v", name, err)
+		}
+		return d
+	}
+
+	seedNS := func(t *testing.T, domainID int32, nameserver string, probe dnsclient.NSProbeResult) {
+		t.Helper()
+		if _, err := pgContainer.Queries.RecordsCreateNS(ctx, store.RecordsCreateNSParams{
+			DomainID:   pgtype.Int4{Int32: domainID, Valid: true},
+			Nameserver: nameserver,
+		}); err != nil {
+			t.Fatalf("Failed to seed NS record %s: %v", nameserver, err)
+		}
+		prober.results[net.JoinHostPort(nameserver, "53")] = probe
+	}
+
+	run := func(t *testing.T, d store.DomainsCreateRow) {
+		t.Helper()
+		a := NewAssessor(Config{
+			Store:    pgContainer.Queries,
+			Logger:   testhelpers.TestLogger,
+			NSProber: prober,
+			Identity: observer.DomainIdentity{
+				TenantID:   1,
+				DomainID:   d.ID,
+				DomainUID:  d.Uid,
+				DomainName: d.Name,
+			},
+		})
+		if err := a.AssessNameserverHealth(ctx, d.Uid); err != nil {
+			t.Fatalf("AssessNameserverHealth failed: %v", err)
+		}
+	}
+
+	getReach := func(t *testing.T, d store.DomainsCreateRow) []store.NameserverReachabilityFindings {
+		t.Helper()
+		f, err := pgContainer.Queries.AssessGetNameserverReachabilityFindingsByDomainUID(ctx,
+			store.AssessGetNameserverReachabilityFindingsByDomainUIDParams{
+				Uid: d.Uid, TenantID: pgtype.Int4{Int32: 1, Valid: true},
+			})
+		if err != nil {
+			t.Fatalf("get reachability: %v", err)
+		}
+		return f
+	}
+	getLatency := func(t *testing.T, d store.DomainsCreateRow) []store.DnsResolutionLatencyFindings {
+		t.Helper()
+		f, err := pgContainer.Queries.AssessGetDNSResolutionLatencyFindingsByDomainUID(ctx,
+			store.AssessGetDNSResolutionLatencyFindingsByDomainUIDParams{
+				Uid: d.Uid, TenantID: pgtype.Int4{Int32: 1, Valid: true},
+			})
+		if err != nil {
+			t.Fatalf("get latency: %v", err)
+		}
+		return f
+	}
+	getConsistency := func(t *testing.T, d store.DomainsCreateRow) []store.DnsResolutionConsistencyFindings {
+		t.Helper()
+		f, err := pgContainer.Queries.AssessGetDNSResolutionConsistencyFindingsByDomainUID(ctx,
+			store.AssessGetDNSResolutionConsistencyFindingsByDomainUIDParams{
+				Uid: d.Uid, TenantID: pgtype.Int4{Int32: 1, Valid: true},
+			})
+		if err != nil {
+			t.Fatalf("get consistency: %v", err)
+		}
+		return f
+	}
+
+	reachByIssue := func(fs []store.NameserverReachabilityFindings, ns, issue string) (store.NameserverReachabilityFindings, bool) {
+		for _, f := range fs {
+			if f.Nameserver == ns && f.IssueType == issue {
+				return f, true
+			}
+		}
+		return store.NameserverReachabilityFindings{}, false
+	}
+	latByResolver := func(fs []store.DnsResolutionLatencyFindings, ns string) (store.DnsResolutionLatencyFindings, bool) {
+		for _, f := range fs {
+			if f.Resolver == ns {
+				return f, true
+			}
+		}
+		return store.DnsResolutionLatencyFindings{}, false
+	}
+
+	healthy := dnsclient.NSProbeResult{
+		Reachable: true, TCPOK: true, HasEDNS: true,
+		RTT: 50 * time.Millisecond, Answers: []string{"soa-serial-100"},
+	}
+
+	t.Run("an unreachable nameserver is a high finding", func(t *testing.T) {
+		d := newDomain(t, "unreachable-ns.test")
+		seedNS(t, d.ID, "ns1.up-host.com", healthy)
+		seedNS(t, d.ID, "ns2.down-host.com", dnsclient.NSProbeResult{Reachable: false})
+		run(t, d)
+
+		f, ok := reachByIssue(getReach(t, d), "ns2.down-host.com", NSUnreachable)
+		if !ok {
+			t.Fatalf("expected unreachable finding for ns2")
+		}
+		if f.Severity != store.FindingSeverityHigh || f.Status != store.FindingStatusOpen {
+			t.Errorf("expected high/open, got %s/%s", f.Severity, f.Status)
+		}
+		if up, ok := reachByIssue(getReach(t, d), "ns1.up-host.com", NSUnreachable); ok {
+			if up.Status != store.FindingStatusResolved {
+				t.Errorf("expected reachable ns1 unreachable=resolved, got %s", up.Status)
+			}
+		}
+	})
+
+	t.Run("a reachable nameserver without TCP is a medium finding", func(t *testing.T) {
+		d := newDomain(t, "notcp-ns.test")
+		probe := healthy
+		probe.TCPOK = false
+		seedNS(t, d.ID, "ns1.notcp-host.com", probe)
+		run(t, d)
+
+		f, ok := reachByIssue(getReach(t, d), "ns1.notcp-host.com", NSNoTCPSupport)
+		if !ok {
+			t.Fatalf("expected no_tcp_support finding")
+		}
+		if f.Severity != store.FindingSeverityMedium || f.Status != store.FindingStatusOpen {
+			t.Errorf("expected medium/open, got %s/%s", f.Severity, f.Status)
+		}
+	})
+
+	t.Run("a reachable nameserver without EDNS is an info finding", func(t *testing.T) {
+		d := newDomain(t, "noedns-ns.test")
+		probe := healthy
+		probe.HasEDNS = false
+		seedNS(t, d.ID, "ns1.noedns-host.com", probe)
+		run(t, d)
+
+		f, ok := reachByIssue(getReach(t, d), "ns1.noedns-host.com", NSNoEDNSSupport)
+		if !ok {
+			t.Fatalf("expected no_edns_support finding")
+		}
+		if f.Severity != store.FindingSeverityInfo || f.Status != store.FindingStatusOpen {
+			t.Errorf("expected info/open, got %s/%s", f.Severity, f.Status)
+		}
+	})
+
+	t.Run("a slow nameserver is tiered by latency", func(t *testing.T) {
+		d := newDomain(t, "slow-ns.test")
+		probe := healthy
+		probe.RTT = 500 * time.Millisecond
+		seedNS(t, d.ID, "ns1.slow-host.com", probe)
+		run(t, d)
+
+		f, ok := latByResolver(getLatency(t, d), "ns1.slow-host.com")
+		if !ok {
+			t.Fatalf("expected latency finding")
+		}
+		if f.Severity != store.FindingSeverityLow || f.Status != store.FindingStatusOpen {
+			t.Errorf("expected low/open, got %s/%s", f.Severity, f.Status)
+		}
+		if f.ThresholdMs != 400 || f.LatencyMs != 500 {
+			t.Errorf("expected threshold 400 / latency 500, got %d/%d", f.ThresholdMs, f.LatencyMs)
+		}
+	})
+
+	t.Run("a fast nameserver records latency as resolved", func(t *testing.T) {
+		d := newDomain(t, "fast-ns.test")
+		seedNS(t, d.ID, "ns1.fast-host.com", healthy)
+		run(t, d)
+
+		f, ok := latByResolver(getLatency(t, d), "ns1.fast-host.com")
+		if !ok {
+			t.Fatalf("expected latency finding")
+		}
+		if f.Status != store.FindingStatusResolved {
+			t.Errorf("expected resolved, got %s", f.Status)
+		}
+	})
+
+	t.Run("divergent SOA serials across nameservers flag consistency", func(t *testing.T) {
+		d := newDomain(t, "divergent-ns.test")
+		p1 := healthy
+		p1.Answers = []string{"soa-serial-100"}
+		p2 := healthy
+		p2.Answers = []string{"soa-serial-200"}
+		seedNS(t, d.ID, "ns1.consistent-a.com", p1)
+		seedNS(t, d.ID, "ns2.consistent-b.com", p2)
+		run(t, d)
+
+		fs := getConsistency(t, d)
+		if len(fs) == 0 {
+			t.Fatalf("expected a consistency finding")
+		}
+		if fs[0].Severity != store.FindingSeverityLow || fs[0].Status != store.FindingStatusOpen {
+			t.Errorf("expected low/open, got %s/%s", fs[0].Severity, fs[0].Status)
+		}
+	})
+
+	t.Run("matching SOA serials record consistency as resolved", func(t *testing.T) {
+		d := newDomain(t, "consistent-ns.test")
+		seedNS(t, d.ID, "ns1.agree-a.com", healthy)
+		seedNS(t, d.ID, "ns2.agree-b.com", healthy)
+		run(t, d)
+
+		for _, f := range getConsistency(t, d) {
+			if f.Status == store.FindingStatusOpen {
+				t.Errorf("expected no open consistency finding, got open %s", f.RecordType)
+			}
+		}
+	})
+
+	t.Run("re-running does not duplicate findings", func(t *testing.T) {
+		d := newDomain(t, "idempotent-health.test")
+		seedNS(t, d.ID, "ns1.idem-host.com", dnsclient.NSProbeResult{Reachable: false})
+		run(t, d)
+		run(t, d)
+
+		var count int
+		for _, f := range getReach(t, d) {
+			if f.Nameserver == "ns1.idem-host.com" && f.IssueType == NSUnreachable {
+				count++
+			}
+		}
+		if count != 1 {
+			t.Errorf("expected exactly one unreachable finding after re-run, got %d", count)
+		}
+	})
+}

--- a/internal/assessor/asssessor.go
+++ b/internal/assessor/asssessor.go
@@ -19,6 +19,10 @@ type Config struct {
 	// HTTPProber probes CNAME targets for the dangling/takeover assessor. Left nil
 	// outside tests; NewAssessor supplies the default outbound prober.
 	HTTPProber HTTPProber
+	// NSProber probes authoritative nameservers directly for the nameserver-health
+	// assessor. Left nil outside tests; NewAssessor defaults it to the DNSClient
+	// when that client supports direct probing.
+	NSProber NameserverProber
 	// Identity is the scan identity used to stamp observations. Left zero in unit
 	// tests (which exercise finding logic without a scan); emission is skipped then.
 	Identity observer.DomainIdentity
@@ -29,6 +33,7 @@ type Assessor struct {
 	store     *store.Queries
 	dnsClient dnsclient.Resolver
 	prober    HTTPProber
+	nsProber  NameserverProber
 	identity  observer.DomainIdentity
 }
 
@@ -48,11 +53,19 @@ func NewAssessor(cfg Config) *Assessor {
 		prober = newHTTPProber()
 	}
 
+	nsProber := cfg.NSProber
+	if nsProber == nil {
+		if p, ok := dnsClient.(NameserverProber); ok {
+			nsProber = p
+		}
+	}
+
 	return &Assessor{
 		store:     cfg.Store,
 		logger:    logger,
 		dnsClient: dnsClient,
 		prober:    prober,
+		nsProber:  nsProber,
 		identity:  cfg.Identity,
 	}
 }

--- a/internal/dnsclient/probe.go
+++ b/internal/dnsclient/probe.go
@@ -1,0 +1,62 @@
+package dnsclient
+
+import (
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// nsProbeTimeout bounds a single direct nameserver exchange. It is long enough
+// not to false-positive on a slow-but-alive nameserver (the medium latency tier
+// is 900ms) yet short enough to surface an unreachable one promptly.
+const nsProbeTimeout = 3 * time.Second
+
+// NSProbeResult captures a direct probe of one authoritative nameserver,
+// produced by ProbeNameserver. It queries a specific server address rather than
+// the configured recursive resolver.
+type NSProbeResult struct {
+	Answers   []string      // rendered answer rdata, for cross-nameserver comparison
+	RTT       time.Duration // round-trip time of the UDP query
+	Rcode     int           // response code of the UDP answer
+	Reachable bool          // the server answered the UDP query
+	HasEDNS   bool          // the UDP response carried an EDNS0 OPT record
+	TCPOK     bool          // the server also answered the same query over TCP
+}
+
+// ProbeNameserver sends a direct, non-recursive query for name/qtype to a
+// specific nameserver address (host:port) over UDP (with EDNS0) and then TCP. It
+// is the active primitive behind the nameserver-health assessor: it measures
+// reachability, latency, EDNS0 and TCP support, and returns the answer set for
+// cross-nameserver consistency comparison.
+//
+// Unlike the LookupX methods it bypasses the fleet L1/DB cache entirely — results
+// are specific to one server and must not pollute the cache, which is keyed only
+// on (qtype, fqdn). It still passes through the fleet rate limiter.
+func (c *DNSClient) ProbeNameserver(server, name string, qtype uint16) NSProbeResult {
+	var res NSProbeResult
+
+	m := new(dns.Msg)
+	m.SetQuestion(dns.Fqdn(name), qtype)
+	m.RecursionDesired = false
+	m.SetEdns0(4096, false)
+
+	udp := &dns.Client{Net: "udp", Timeout: nsProbeTimeout}
+	if c.limiter.Acquire() {
+		if r, rtt, err := udp.Exchange(m, server); err == nil && r != nil {
+			res.Reachable = true
+			res.RTT = rtt
+			res.Rcode = r.Rcode
+			res.HasEDNS = r.IsEdns0() != nil
+			res.Answers = processResponse(r, qtype)
+		}
+	}
+
+	tcp := &dns.Client{Net: "tcp", Timeout: nsProbeTimeout}
+	if c.limiter.Acquire() {
+		if r, _, err := tcp.Exchange(m, server); err == nil && r != nil {
+			res.TCPOK = true
+		}
+	}
+
+	return res
+}

--- a/internal/jobs/assess_jobs.go
+++ b/internal/jobs/assess_jobs.go
@@ -392,3 +392,50 @@ func (w *AssessNameserverConfigWorker) Work(
 	)
 	return nil
 }
+
+type AssessNameserverHealthArgs struct {
+	DomainJobArgs
+}
+
+func (AssessNameserverHealthArgs) InsertOpts() river.InsertOpts {
+	return river.InsertOpts{
+		Queue: queueAssessor,
+	}
+}
+func (AssessNameserverHealthArgs) Kind() string { return "assess_nameserver_health" }
+
+type AssessNameserverHealthWorker struct {
+	river.WorkerDefaults[AssessNameserverHealthArgs]
+	Logger   slog.Logger
+	Store    *store.Queries
+	PgxPool  *pgxpool.Pool
+	Resolver dnsclient.Resolver
+}
+
+func (w *AssessNameserverHealthWorker) Work(
+	ctx context.Context,
+	job *river.Job[AssessNameserverHealthArgs],
+) error {
+	ctx = tracing.WithNewTraceID(ctx, false)
+	start := time.Now()
+	w.Logger.InfoContext(ctx, "assess nameserver health started", "domain", job.Args.DomainUID)
+	a := assessor.NewAssessor(assessor.Config{
+		Logger:    &w.Logger,
+		Store:     w.Store,
+		DNSClient: w.Resolver,
+		Identity:  job.Args.Identity(),
+	})
+	if err := a.AssessNameserverHealth(ctx, job.Args.DomainUID); err != nil {
+		return err
+	}
+
+	w.Logger.InfoContext(
+		ctx,
+		"assess nameserver health complete",
+		"domain",
+		job.Args.DomainUID,
+		"duration",
+		time.Since(start),
+	)
+	return nil
+}

--- a/internal/jobs/enumerate_jobs.go
+++ b/internal/jobs/enumerate_jobs.go
@@ -263,6 +263,14 @@ func (w *ResolveDomainWorker) Work(ctx context.Context, job *river.Job[ResolveDo
 			"domain", job.Args.DomainUID, "error", err)
 	}
 
+	// Nameserver health assessment probes each authoritative NS directly; an
+	// unreachable nameserver is itself a finding, so it runs unconditionally.
+	if err := enqueueAssessment(ctx, w.PgxPool, &w.Logger, job.Args.DomainUID,
+		AssessNameserverHealthArgs{DomainJobArgs: job.Args.DomainJobArgs}); err != nil {
+		w.Logger.WarnContext(ctx, "failed to queue nameserver health assessment",
+			"domain", job.Args.DomainUID, "error", err)
+	}
+
 	// Email security assessment is data-dependent: enqueue only when TXT records
 	// were discovered (SPF/DKIM/DMARC live in TXT).
 	if len(resolved.TXT.Entries) > 0 {

--- a/internal/jobs/river.go
+++ b/internal/jobs/river.go
@@ -198,6 +198,15 @@ func New(ctx context.Context, cfg Config) (*river.Client[pgx.Tx], error) {
 				Resolver: cfg.Resolver,
 			},
 		)
+		river.AddWorker(
+			rw,
+			&AssessNameserverHealthWorker{
+				Logger:   *cfg.Logger,
+				Store:    cfg.Store,
+				PgxPool:  cfg.PgxPool,
+				Resolver: cfg.Resolver,
+			},
+		)
 		// maintenance
 		river.AddWorker(rw, &PurgeDNSCacheWorker{Logger: *cfg.Logger, Store: cfg.Store})
 		river.AddWorker(rw, &RefreshTenantStatsWorker{Logger: *cfg.Logger, Store: cfg.Store})

--- a/internal/observer/recorder.go
+++ b/internal/observer/recorder.go
@@ -63,6 +63,10 @@ const (
 	EntityNSConfigurationFinding      = "ns_configuration_finding"
 	EntityNameserverRedundancyFinding = "nameserver_redundancy_finding"
 
+	EntityNameserverReachabilityFinding   = "nameserver_reachability_finding"
+	EntityDNSResolutionLatencyFinding     = "dns_resolution_latency_finding"
+	EntityDNSResolutionConsistencyFinding = "dns_resolution_consistency_finding"
+
 	// EntityDomain is used only on lifecycle NOTIFY signals (create/delete/status),
 	// never stored as an observation — a domain's existence is the projection
 	// itself. It lets the UI refresh on changes that write no observation row.

--- a/internal/server/findings_handlers.go
+++ b/internal/server/findings_handlers.go
@@ -44,7 +44,7 @@ func toFindingItem(f service.FindingView) FindingItem {
 
 type FindingsListInput struct {
 	Severity         string `query:"severity"          example:"crit"  doc:"Filter by tier: crit|high|med|low. Optional." enum:"crit,high,med,low,"`
-	Kind             string `query:"kind"              example:"SPF"   doc:"Filter by type: SPF|DKIM|DMARC|ZONE|CERT|DNSSEC|CAA_CONFIG|CAA_COMPLIANCE|MIN_RECORDS|EMAIL_COMPLIANCE|NS_CONFIG|NS_REDUNDANCY. Optional." enum:"SPF,DKIM,DMARC,ZONE,CERT,DNSSEC,CAA_CONFIG,CAA_COMPLIANCE,MIN_RECORDS,EMAIL_COMPLIANCE,NS_CONFIG,NS_REDUNDANCY,"`
+	Kind             string `query:"kind"              example:"SPF"   doc:"Filter by type: SPF|DKIM|DMARC|ZONE|CERT|DNSSEC|CAA_CONFIG|CAA_COMPLIANCE|MIN_RECORDS|EMAIL_COMPLIANCE|NS_CONFIG|NS_REDUNDANCY|NS_REACHABILITY|NS_LATENCY|NS_CONSISTENCY. Optional." enum:"SPF,DKIM,DMARC,ZONE,CERT,DNSSEC,CAA_CONFIG,CAA_COMPLIANCE,MIN_RECORDS,EMAIL_COMPLIANCE,NS_CONFIG,NS_REDUNDANCY,NS_REACHABILITY,NS_LATENCY,NS_CONSISTENCY,"`
 	DomainQuery      string `query:"q"                 example:"acme"  doc:"Case-insensitive domain-name substring. Optional."`
 	IncludeCompliant bool   `query:"include_compliant" example:"false" doc:"Include compliant/closed findings. Optional."`
 	PaginationQuery

--- a/internal/service/findings.go
+++ b/internal/service/findings.go
@@ -231,6 +231,36 @@ func (s *FindingsService) ListByDomain(
 			))
 		}
 	}
+	if nsReach, err := s.DB.AssessGetNameserverReachabilityFindingsByDomainUID(ctx, store.AssessGetNameserverReachabilityFindingsByDomainUIDParams{
+		Uid:      domainUID,
+		TenantID: tenantID,
+	}); err == nil {
+		for _, f := range nsReach {
+			findings = append(findings, mapStandardFinding(
+				"NS_REACHABILITY", f.Severity, f.Status, f.IssueType, f.Details,
+			))
+		}
+	}
+	if nsLatency, err := s.DB.AssessGetDNSResolutionLatencyFindingsByDomainUID(ctx, store.AssessGetDNSResolutionLatencyFindingsByDomainUIDParams{
+		Uid:      domainUID,
+		TenantID: tenantID,
+	}); err == nil {
+		for _, f := range nsLatency {
+			findings = append(findings, mapStandardFinding(
+				"NS_LATENCY", f.Severity, f.Status, "high_latency", f.Details,
+			))
+		}
+	}
+	if nsConsistency, err := s.DB.AssessGetDNSResolutionConsistencyFindingsByDomainUID(ctx, store.AssessGetDNSResolutionConsistencyFindingsByDomainUIDParams{
+		Uid:      domainUID,
+		TenantID: tenantID,
+	}); err == nil {
+		for _, f := range nsConsistency {
+			findings = append(findings, mapStandardFinding(
+				"NS_CONSISTENCY", f.Severity, f.Status, "resolver_mismatch", f.Details,
+			))
+		}
+	}
 
 	sort.SliceStable(findings, func(i, j int) bool {
 		return severityRank(findings[i].Severity) < severityRank(findings[j].Severity)
@@ -636,6 +666,11 @@ var findingTitles = map[string]string{
 	"no_ipv6":                      "No nameserver reachable over IPv6",
 	"ns_not_resolvable":            "Nameserver does not resolve",
 	"ns_is_cname":                  "Nameserver is a CNAME (illegal)",
+	"unreachable":                  "Nameserver is unreachable",
+	"no_tcp_support":               "Nameserver doesn't answer over TCP",
+	"no_edns_support":              "Nameserver doesn't support EDNS0",
+	"high_latency":                 "Nameserver response is slow",
+	"resolver_mismatch":            "Nameservers return divergent answers",
 	"missing_apex_address":         "Apex has no A/AAAA record",
 	"missing_ipv6":                 "No IPv6 (AAAA) at apex",
 	"missing_soa":                  "No SOA record at apex",
@@ -691,6 +726,11 @@ var findingFixes = map[string]string{
 	"no_ipv6":                      "Add AAAA glue for at least one nameserver so IPv6-only resolvers can reach the zone.",
 	"ns_not_resolvable":            "Publish A/AAAA glue for the nameserver, or remove the stale delegation.",
 	"ns_is_cname":                  "Point the NS record at a host with A/AAAA records, not a CNAME (RFC 2181).",
+	"unreachable":                  "Ensure the nameserver answers DNS queries on UDP/53 and is correctly delegated.",
+	"no_tcp_support":               "Allow DNS over TCP/53; it is required for large responses and DNSSEC.",
+	"no_edns_support":              "Enable EDNS0 on the nameserver for modern DNS features and larger UDP responses.",
+	"high_latency":                 "Investigate nameserver/network latency; consider anycast or a closer provider.",
+	"resolver_mismatch":            "Reconcile zone data across nameservers; if mid-propagation, re-check after TTLs expire.",
 	"missing_apex_address":         "Publish an A and/or AAAA record at the apex.",
 	"missing_ipv6":                 "Add an AAAA record to make the apex reachable over IPv6.",
 	"missing_soa":                  "Ensure the zone publishes a SOA record at its apex.",

--- a/internal/store/assessors.sql.go
+++ b/internal/store/assessors.sql.go
@@ -271,6 +271,103 @@ func (q *Queries) AssessCreateDMARCFinding(ctx context.Context, arg AssessCreate
 	return inserted, err
 }
 
+const assessCreateDNSResolutionConsistencyFinding = `-- name: AssessCreateDNSResolutionConsistencyFinding :one
+INSERT INTO dns_resolution_consistency_findings (domain_id,
+                                                 severity,
+                                                 status,
+                                                 record_type,
+                                                 resolver1,
+                                                 resolver1_result,
+                                                 resolver2,
+                                                 resolver2_result,
+                                                 details)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+ON CONFLICT (domain_id, record_type)
+    DO UPDATE SET severity         = $2,
+                  status           = $3,
+                  resolver1        = $5,
+                  resolver1_result = $6,
+                  resolver2        = $7,
+                  resolver2_result = $8,
+                  details          = $9
+RETURNING (xmax = 0)::boolean AS inserted
+`
+
+type AssessCreateDNSResolutionConsistencyFindingParams struct {
+	DomainID        pgtype.Int4     `json:"domain_id"`
+	Severity        FindingSeverity `json:"severity"`
+	Status          FindingStatus   `json:"status"`
+	RecordType      string          `json:"record_type"`
+	Resolver1       string          `json:"resolver1"`
+	Resolver1Result pgtype.Text     `json:"resolver1_result"`
+	Resolver2       string          `json:"resolver2"`
+	Resolver2Result pgtype.Text     `json:"resolver2_result"`
+	Details         pgtype.Text     `json:"details"`
+}
+
+func (q *Queries) AssessCreateDNSResolutionConsistencyFinding(ctx context.Context, arg AssessCreateDNSResolutionConsistencyFindingParams) (bool, error) {
+	row := q.db.QueryRow(ctx, assessCreateDNSResolutionConsistencyFinding,
+		arg.DomainID,
+		arg.Severity,
+		arg.Status,
+		arg.RecordType,
+		arg.Resolver1,
+		arg.Resolver1Result,
+		arg.Resolver2,
+		arg.Resolver2Result,
+		arg.Details,
+	)
+	var inserted bool
+	err := row.Scan(&inserted)
+	return inserted, err
+}
+
+const assessCreateDNSResolutionLatencyFinding = `-- name: AssessCreateDNSResolutionLatencyFinding :one
+INSERT INTO dns_resolution_latency_findings (domain_id,
+                                             severity,
+                                             status,
+                                             record_type,
+                                             resolver,
+                                             latency_ms,
+                                             threshold_ms,
+                                             details)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+ON CONFLICT (domain_id, resolver, record_type)
+    DO UPDATE SET severity     = $2,
+                  status       = $3,
+                  latency_ms   = $6,
+                  threshold_ms = $7,
+                  details      = $8
+RETURNING (xmax = 0)::boolean AS inserted
+`
+
+type AssessCreateDNSResolutionLatencyFindingParams struct {
+	DomainID    pgtype.Int4     `json:"domain_id"`
+	Severity    FindingSeverity `json:"severity"`
+	Status      FindingStatus   `json:"status"`
+	RecordType  string          `json:"record_type"`
+	Resolver    string          `json:"resolver"`
+	LatencyMs   int32           `json:"latency_ms"`
+	ThresholdMs int32           `json:"threshold_ms"`
+	Details     pgtype.Text     `json:"details"`
+}
+
+func (q *Queries) AssessCreateDNSResolutionLatencyFinding(ctx context.Context, arg AssessCreateDNSResolutionLatencyFindingParams) (bool, error) {
+	row := q.db.QueryRow(ctx, assessCreateDNSResolutionLatencyFinding,
+		arg.DomainID,
+		arg.Severity,
+		arg.Status,
+		arg.RecordType,
+		arg.Resolver,
+		arg.LatencyMs,
+		arg.ThresholdMs,
+		arg.Details,
+	)
+	var inserted bool
+	err := row.Scan(&inserted)
+	return inserted, err
+}
+
 const assessCreateDNSSECFinding = `-- name: AssessCreateDNSSECFinding :one
 INSERT INTO dnssec_findings (domain_id,
                              severity,
@@ -426,6 +523,52 @@ func (q *Queries) AssessCreateNSConfigurationFinding(ctx context.Context, arg As
 		arg.Status,
 		arg.IssueType,
 		arg.Nameserver,
+		arg.Details,
+	)
+	var inserted bool
+	err := row.Scan(&inserted)
+	return inserted, err
+}
+
+const assessCreateNameserverReachabilityFinding = `-- name: AssessCreateNameserverReachabilityFinding :one
+INSERT INTO nameserver_reachability_findings (domain_id,
+                                              ns_record_id,
+                                              severity,
+                                              status,
+                                              nameserver,
+                                              issue_type,
+                                              response_time_ms,
+                                              details)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+ON CONFLICT (domain_id, nameserver, issue_type)
+    DO UPDATE SET ns_record_id     = $2,
+                  severity         = $3,
+                  status           = $4,
+                  response_time_ms = $7,
+                  details          = $8
+RETURNING (xmax = 0)::boolean AS inserted
+`
+
+type AssessCreateNameserverReachabilityFindingParams struct {
+	DomainID       pgtype.Int4     `json:"domain_id"`
+	NsRecordID     pgtype.Int4     `json:"ns_record_id"`
+	Severity       FindingSeverity `json:"severity"`
+	Status         FindingStatus   `json:"status"`
+	Nameserver     string          `json:"nameserver"`
+	IssueType      string          `json:"issue_type"`
+	ResponseTimeMs pgtype.Int4     `json:"response_time_ms"`
+	Details        pgtype.Text     `json:"details"`
+}
+
+func (q *Queries) AssessCreateNameserverReachabilityFinding(ctx context.Context, arg AssessCreateNameserverReachabilityFindingParams) (bool, error) {
+	row := q.db.QueryRow(ctx, assessCreateNameserverReachabilityFinding,
+		arg.DomainID,
+		arg.NsRecordID,
+		arg.Severity,
+		arg.Status,
+		arg.Nameserver,
+		arg.IssueType,
+		arg.ResponseTimeMs,
 		arg.Details,
 	)
 	var inserted bool
@@ -875,6 +1018,101 @@ func (q *Queries) AssessGetDMARCFindingsByDomainID(ctx context.Context, arg Asse
 	return items, nil
 }
 
+const assessGetDNSResolutionConsistencyFindingsByDomainUID = `-- name: AssessGetDNSResolutionConsistencyFindingsByDomainUID :many
+SELECT con.id, con.uid, con.domain_id, con.severity, con.status, con.record_type, con.resolver1, con.resolver1_result, con.resolver2, con.resolver2_result, con.details, con.created_at, con.updated_at
+FROM dns_resolution_consistency_findings con
+         JOIN domains d ON con.domain_id = d.id
+WHERE d.uid = $1
+  AND d.tenant_id = $2
+ORDER BY con.severity ASC, con.created_at DESC
+`
+
+type AssessGetDNSResolutionConsistencyFindingsByDomainUIDParams struct {
+	Uid      string      `json:"uid"`
+	TenantID pgtype.Int4 `json:"tenant_id"`
+}
+
+func (q *Queries) AssessGetDNSResolutionConsistencyFindingsByDomainUID(ctx context.Context, arg AssessGetDNSResolutionConsistencyFindingsByDomainUIDParams) ([]DnsResolutionConsistencyFindings, error) {
+	rows, err := q.db.Query(ctx, assessGetDNSResolutionConsistencyFindingsByDomainUID, arg.Uid, arg.TenantID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []DnsResolutionConsistencyFindings{}
+	for rows.Next() {
+		var i DnsResolutionConsistencyFindings
+		if err := rows.Scan(
+			&i.ID,
+			&i.Uid,
+			&i.DomainID,
+			&i.Severity,
+			&i.Status,
+			&i.RecordType,
+			&i.Resolver1,
+			&i.Resolver1Result,
+			&i.Resolver2,
+			&i.Resolver2Result,
+			&i.Details,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const assessGetDNSResolutionLatencyFindingsByDomainUID = `-- name: AssessGetDNSResolutionLatencyFindingsByDomainUID :many
+SELECT lat.id, lat.uid, lat.domain_id, lat.severity, lat.status, lat.record_type, lat.resolver, lat.latency_ms, lat.threshold_ms, lat.details, lat.created_at, lat.updated_at
+FROM dns_resolution_latency_findings lat
+         JOIN domains d ON lat.domain_id = d.id
+WHERE d.uid = $1
+  AND d.tenant_id = $2
+ORDER BY lat.severity ASC, lat.created_at DESC
+`
+
+type AssessGetDNSResolutionLatencyFindingsByDomainUIDParams struct {
+	Uid      string      `json:"uid"`
+	TenantID pgtype.Int4 `json:"tenant_id"`
+}
+
+func (q *Queries) AssessGetDNSResolutionLatencyFindingsByDomainUID(ctx context.Context, arg AssessGetDNSResolutionLatencyFindingsByDomainUIDParams) ([]DnsResolutionLatencyFindings, error) {
+	rows, err := q.db.Query(ctx, assessGetDNSResolutionLatencyFindingsByDomainUID, arg.Uid, arg.TenantID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []DnsResolutionLatencyFindings{}
+	for rows.Next() {
+		var i DnsResolutionLatencyFindings
+		if err := rows.Scan(
+			&i.ID,
+			&i.Uid,
+			&i.DomainID,
+			&i.Severity,
+			&i.Status,
+			&i.RecordType,
+			&i.Resolver,
+			&i.LatencyMs,
+			&i.ThresholdMs,
+			&i.Details,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const assessGetDNSSECFindingsByDomainUID = `-- name: AssessGetDNSSECFindingsByDomainUID :many
 SELECT df.id, df.uid, df.domain_id, df.dnskey_record_id, df.ds_record_id, df.severity, df.status, df.issue_type, df.details, df.created_at, df.updated_at
 FROM dnssec_findings df
@@ -1091,6 +1329,53 @@ func (q *Queries) AssessGetNSConfigurationFindingsByDomainUID(ctx context.Contex
 			&i.Status,
 			&i.IssueType,
 			&i.Nameserver,
+			&i.Details,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const assessGetNameserverReachabilityFindingsByDomainUID = `-- name: AssessGetNameserverReachabilityFindingsByDomainUID :many
+SELECT rch.id, rch.uid, rch.domain_id, rch.ns_record_id, rch.severity, rch.status, rch.nameserver, rch.issue_type, rch.response_time_ms, rch.details, rch.created_at, rch.updated_at
+FROM nameserver_reachability_findings rch
+         JOIN domains d ON rch.domain_id = d.id
+WHERE d.uid = $1
+  AND d.tenant_id = $2
+ORDER BY rch.severity ASC, rch.created_at DESC
+`
+
+type AssessGetNameserverReachabilityFindingsByDomainUIDParams struct {
+	Uid      string      `json:"uid"`
+	TenantID pgtype.Int4 `json:"tenant_id"`
+}
+
+func (q *Queries) AssessGetNameserverReachabilityFindingsByDomainUID(ctx context.Context, arg AssessGetNameserverReachabilityFindingsByDomainUIDParams) ([]NameserverReachabilityFindings, error) {
+	rows, err := q.db.Query(ctx, assessGetNameserverReachabilityFindingsByDomainUID, arg.Uid, arg.TenantID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []NameserverReachabilityFindings{}
+	for rows.Next() {
+		var i NameserverReachabilityFindings
+		if err := rows.Scan(
+			&i.ID,
+			&i.Uid,
+			&i.DomainID,
+			&i.NsRecordID,
+			&i.Severity,
+			&i.Status,
+			&i.Nameserver,
+			&i.IssueType,
+			&i.ResponseTimeMs,
 			&i.Details,
 			&i.CreatedAt,
 			&i.UpdatedAt,
@@ -1372,6 +1657,15 @@ open_findings AS (
     UNION ALL
     SELECT domain_id, severity::text FROM nameserver_redundancy_findings
         WHERE status = 'open' AND domain_id = ANY($1::int[])
+    UNION ALL
+    SELECT domain_id, severity::text FROM nameserver_reachability_findings
+        WHERE status = 'open' AND domain_id = ANY($1::int[])
+    UNION ALL
+    SELECT domain_id, severity::text FROM dns_resolution_latency_findings
+        WHERE status = 'open' AND domain_id = ANY($1::int[])
+    UNION ALL
+    SELECT domain_id, severity::text FROM dns_resolution_consistency_findings
+        WHERE status = 'open' AND domain_id = ANY($1::int[])
 )
 SELECT
     ids.domain_id::int AS domain_id,
@@ -1566,7 +1860,34 @@ FROM (SELECT sf.uid                AS finding_uid,
       FROM nameserver_redundancy_findings nrf
                JOIN domains d ON nrf.domain_id = d.id
       WHERE d.tenant_id = $1
-        AND ($2::bool OR nrf.status = 'open')) f
+        AND ($2::bool OR nrf.status = 'open')
+
+      UNION ALL
+
+      SELECT rch.uid, d.uid, d.name, 'NS_REACHABILITY'::text, rch.severity, rch.status,
+             rch.issue_type, rch.nameserver, rch.details, NULL::text, rch.created_at
+      FROM nameserver_reachability_findings rch
+               JOIN domains d ON rch.domain_id = d.id
+      WHERE d.tenant_id = $1
+        AND ($2::bool OR rch.status = 'open')
+
+      UNION ALL
+
+      SELECT lat.uid, d.uid, d.name, 'NS_LATENCY'::text, lat.severity, lat.status,
+             'high_latency'::text, lat.resolver, lat.details, NULL::text, lat.created_at
+      FROM dns_resolution_latency_findings lat
+               JOIN domains d ON lat.domain_id = d.id
+      WHERE d.tenant_id = $1
+        AND ($2::bool OR lat.status = 'open')
+
+      UNION ALL
+
+      SELECT con.uid, d.uid, d.name, 'NS_CONSISTENCY'::text, con.severity, con.status,
+             'resolver_mismatch'::text, con.record_type, con.details, NULL::text, con.created_at
+      FROM dns_resolution_consistency_findings con
+               JOIN domains d ON con.domain_id = d.id
+      WHERE d.tenant_id = $1
+        AND ($2::bool OR con.status = 'open')) f
 ORDER BY f.domain_name ASC,
          CASE f.severity
              WHEN 'critical' THEN 1
@@ -1817,6 +2138,12 @@ FROM (
         SELECT domain_id, severity::text FROM ns_configuration_findings WHERE status = 'open'
         UNION ALL
         SELECT domain_id, severity::text FROM nameserver_redundancy_findings WHERE status = 'open'
+        UNION ALL
+        SELECT domain_id, severity::text FROM nameserver_reachability_findings WHERE status = 'open'
+        UNION ALL
+        SELECT domain_id, severity::text FROM dns_resolution_latency_findings WHERE status = 'open'
+        UNION ALL
+        SELECT domain_id, severity::text FROM dns_resolution_consistency_findings WHERE status = 'open'
     ) f ON f.domain_id = d.id
     GROUP BY d.tenant_id, d.id
 ) agg

--- a/internal/ui/findings_handlers.go
+++ b/internal/ui/findings_handlers.go
@@ -102,6 +102,9 @@ var findingKindOrder = []string{
 	"EMAIL_COMPLIANCE",
 	"NS_CONFIG",
 	"NS_REDUNDANCY",
+	"NS_REACHABILITY",
+	"NS_LATENCY",
+	"NS_CONSISTENCY",
 }
 
 var findingKindLabels = map[string]string{
@@ -117,6 +120,9 @@ var findingKindLabels = map[string]string{
 	"EMAIL_COMPLIANCE": "Email compliance",
 	"NS_CONFIG":        "Nameserver configuration",
 	"NS_REDUNDANCY":    "Nameserver redundancy",
+	"NS_REACHABILITY":  "Nameserver reachability",
+	"NS_LATENCY":       "Nameserver latency",
+	"NS_CONSISTENCY":   "Nameserver consistency",
 }
 
 // kindOptions builds the data-driven type dropdown from the faceted KindCounts.

--- a/sql/queries/assessors.sql
+++ b/sql/queries/assessors.sql
@@ -209,6 +209,87 @@ WHERE d.uid = $1
   AND d.tenant_id = $2
 ORDER BY nrf.severity ASC, nrf.created_at DESC;
 
+-- name: AssessCreateNameserverReachabilityFinding :one
+INSERT INTO nameserver_reachability_findings (domain_id,
+                                              ns_record_id,
+                                              severity,
+                                              status,
+                                              nameserver,
+                                              issue_type,
+                                              response_time_ms,
+                                              details)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+ON CONFLICT (domain_id, nameserver, issue_type)
+    DO UPDATE SET ns_record_id     = $2,
+                  severity         = $3,
+                  status           = $4,
+                  response_time_ms = $7,
+                  details          = $8
+RETURNING (xmax = 0)::boolean AS inserted;
+
+-- name: AssessGetNameserverReachabilityFindingsByDomainUID :many
+SELECT rch.*
+FROM nameserver_reachability_findings rch
+         JOIN domains d ON rch.domain_id = d.id
+WHERE d.uid = $1
+  AND d.tenant_id = $2
+ORDER BY rch.severity ASC, rch.created_at DESC;
+
+-- name: AssessCreateDNSResolutionLatencyFinding :one
+INSERT INTO dns_resolution_latency_findings (domain_id,
+                                             severity,
+                                             status,
+                                             record_type,
+                                             resolver,
+                                             latency_ms,
+                                             threshold_ms,
+                                             details)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+ON CONFLICT (domain_id, resolver, record_type)
+    DO UPDATE SET severity     = $2,
+                  status       = $3,
+                  latency_ms   = $6,
+                  threshold_ms = $7,
+                  details      = $8
+RETURNING (xmax = 0)::boolean AS inserted;
+
+-- name: AssessGetDNSResolutionLatencyFindingsByDomainUID :many
+SELECT lat.*
+FROM dns_resolution_latency_findings lat
+         JOIN domains d ON lat.domain_id = d.id
+WHERE d.uid = $1
+  AND d.tenant_id = $2
+ORDER BY lat.severity ASC, lat.created_at DESC;
+
+-- name: AssessCreateDNSResolutionConsistencyFinding :one
+INSERT INTO dns_resolution_consistency_findings (domain_id,
+                                                 severity,
+                                                 status,
+                                                 record_type,
+                                                 resolver1,
+                                                 resolver1_result,
+                                                 resolver2,
+                                                 resolver2_result,
+                                                 details)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+ON CONFLICT (domain_id, record_type)
+    DO UPDATE SET severity         = $2,
+                  status           = $3,
+                  resolver1        = $5,
+                  resolver1_result = $6,
+                  resolver2        = $7,
+                  resolver2_result = $8,
+                  details          = $9
+RETURNING (xmax = 0)::boolean AS inserted;
+
+-- name: AssessGetDNSResolutionConsistencyFindingsByDomainUID :many
+SELECT con.*
+FROM dns_resolution_consistency_findings con
+         JOIN domains d ON con.domain_id = d.id
+WHERE d.uid = $1
+  AND d.tenant_id = $2
+ORDER BY con.severity ASC, con.created_at DESC;
+
 -- name: StoreDanglingCnameFinding :one
 INSERT INTO dangling_cname_findings (domain_id,
                                      severity,
@@ -439,6 +520,15 @@ open_findings AS (
     UNION ALL
     SELECT domain_id, severity::text FROM nameserver_redundancy_findings
         WHERE status = 'open' AND domain_id = ANY(@domain_ids::int[])
+    UNION ALL
+    SELECT domain_id, severity::text FROM nameserver_reachability_findings
+        WHERE status = 'open' AND domain_id = ANY(@domain_ids::int[])
+    UNION ALL
+    SELECT domain_id, severity::text FROM dns_resolution_latency_findings
+        WHERE status = 'open' AND domain_id = ANY(@domain_ids::int[])
+    UNION ALL
+    SELECT domain_id, severity::text FROM dns_resolution_consistency_findings
+        WHERE status = 'open' AND domain_id = ANY(@domain_ids::int[])
 )
 SELECT
     ids.domain_id::int AS domain_id,
@@ -608,7 +698,34 @@ FROM (SELECT sf.uid                AS finding_uid,
       FROM nameserver_redundancy_findings nrf
                JOIN domains d ON nrf.domain_id = d.id
       WHERE d.tenant_id = @tenant_id
-        AND (@include_compliant::bool OR nrf.status = 'open')) f
+        AND (@include_compliant::bool OR nrf.status = 'open')
+
+      UNION ALL
+
+      SELECT rch.uid, d.uid, d.name, 'NS_REACHABILITY'::text, rch.severity, rch.status,
+             rch.issue_type, rch.nameserver, rch.details, NULL::text, rch.created_at
+      FROM nameserver_reachability_findings rch
+               JOIN domains d ON rch.domain_id = d.id
+      WHERE d.tenant_id = @tenant_id
+        AND (@include_compliant::bool OR rch.status = 'open')
+
+      UNION ALL
+
+      SELECT lat.uid, d.uid, d.name, 'NS_LATENCY'::text, lat.severity, lat.status,
+             'high_latency'::text, lat.resolver, lat.details, NULL::text, lat.created_at
+      FROM dns_resolution_latency_findings lat
+               JOIN domains d ON lat.domain_id = d.id
+      WHERE d.tenant_id = @tenant_id
+        AND (@include_compliant::bool OR lat.status = 'open')
+
+      UNION ALL
+
+      SELECT con.uid, d.uid, d.name, 'NS_CONSISTENCY'::text, con.severity, con.status,
+             'resolver_mismatch'::text, con.record_type, con.details, NULL::text, con.created_at
+      FROM dns_resolution_consistency_findings con
+               JOIN domains d ON con.domain_id = d.id
+      WHERE d.tenant_id = @tenant_id
+        AND (@include_compliant::bool OR con.status = 'open')) f
 ORDER BY f.domain_name ASC,
          CASE f.severity
              WHEN 'critical' THEN 1
@@ -668,6 +785,12 @@ FROM (
         SELECT domain_id, severity::text FROM ns_configuration_findings WHERE status = 'open'
         UNION ALL
         SELECT domain_id, severity::text FROM nameserver_redundancy_findings WHERE status = 'open'
+        UNION ALL
+        SELECT domain_id, severity::text FROM nameserver_reachability_findings WHERE status = 'open'
+        UNION ALL
+        SELECT domain_id, severity::text FROM dns_resolution_latency_findings WHERE status = 'open'
+        UNION ALL
+        SELECT domain_id, severity::text FROM dns_resolution_consistency_findings WHERE status = 'open'
     ) f ON f.domain_id = d.id
     GROUP BY d.tenant_id, d.id
 ) agg


### PR DESCRIPTION
Wires up three dormant tables — `nameserver_reachability_findings`, `dns_resolution_latency_findings`, `dns_resolution_consistency_findings` (EPIC #61). This is the first assessor to query **each authoritative nameserver directly** rather than the recursive resolver.

## New primitive

`dnsclient.ProbeNameserver` — a rate-limiter-gated, **cache-bypassing** direct query that captures RTT and probes UDP+EDNS0 then TCP. The assessor reaches it through a `NameserverProber` seam (mirroring the existing `HTTPProber` seam), so the whole assessor is unit-testable with a fake prober and **no network/mock DNS server**.

## Checks (one SOA probe per NS serves them all)

| Check | issue_type | severity | kind |
|---|---|---|---|
| No UDP answer | `unreachable` | high | `NS_REACHABILITY` |
| No TCP answer | `no_tcp_support` | medium | `NS_REACHABILITY` |
| No EDNS0 | `no_edns_support` | info | `NS_REACHABILITY` |
| Slow response | `high_latency` | info/low/medium | `NS_LATENCY` |
| Divergent SOA serials | `resolver_mismatch` | low | `NS_CONSISTENCY` |

Latency tiers (Balanced): info ≥150ms, low ≥400ms, medium ≥900ms. The apex SOA is probed because its serial is the canonical "are the nameservers in sync" signal.

## Notes

- **Cost:** ~2 queries (UDP+TCP) × N nameservers per domain, all through the fleet rate limiter; the probe bypasses the L1/DB cache since results are server-specific.
- Idempotent upserts via new UNIQUE constraints (migration `00028`); checks re-run each scan and auto-resolve.
- Enqueued unconditionally from `ResolveDomainWorker`.

## Deferred (scope note)

The consistency check **omits cross-scan dampening**: nameservers legitimately disagree during propagation, so divergence is flagged at low severity with a "may be transient propagation" note. Requiring divergence to persist across N consecutive scans needs cross-scan state that doesn't exist today — a follow-up.

Closes #65
