### PR TITLE
MTA-STS & TLS-RPT assessor

### DIFF
--- a/internal/assessor/assess_bimi.go
+++ b/internal/assessor/assess_bimi.go
@@ -44,7 +44,7 @@ func (a *Assessor) assessBIMI(ctx context.Context, d assessData) error {
 
 	bimiRecord := a.lookupBIMIRecord(domain.Name)
 	if bimiRecord == "" {
-		return a.createComplianceFinding(ctx, d.domainID, BIMIAuthType,
+		return a.createComplianceFinding(ctx, d.domainID, BIMIAuthType, bimiStandardName,
 			store.FindingSeverityInfo, store.FindingStatusNotApplicable, BIMINotConfigured,
 			"BIMI is not configured (optional brand-indicator feature)")
 	}
@@ -54,7 +54,7 @@ func (a *Assessor) assessBIMI(ctx context.Context, d assessData) error {
 
 	if !a.dmarcEnforced(domain.Name) {
 		issues = true
-		if err := a.createComplianceFinding(ctx, d.domainID, BIMIAuthType,
+		if err := a.createComplianceFinding(ctx, d.domainID, BIMIAuthType, bimiStandardName,
 			store.FindingSeverityMedium, store.FindingStatusOpen, BIMIRequiresEnforcedDMARC,
 			"BIMI is published but DMARC is not enforced; BIMI requires p=quarantine or p=reject"); err != nil {
 			return err
@@ -64,7 +64,7 @@ func (a *Assessor) assessBIMI(ctx context.Context, d assessData) error {
 	logo := tags["l"]
 	if logo == "" || !isHTTPSURL(logo) || !isSVGURL(logo) {
 		issues = true
-		if err := a.createComplianceFinding(ctx, d.domainID, BIMIAuthType,
+		if err := a.createComplianceFinding(ctx, d.domainID, BIMIAuthType, bimiStandardName,
 			store.FindingSeverityLow, store.FindingStatusOpen, BIMIInvalidLogo,
 			"BIMI l= must reference an HTTPS URL to an SVG logo"); err != nil {
 			return err
@@ -73,7 +73,7 @@ func (a *Assessor) assessBIMI(ctx context.Context, d assessData) error {
 
 	if vmc := tags["a"]; vmc != "" && !isHTTPSURL(vmc) {
 		issues = true
-		if err := a.createComplianceFinding(ctx, d.domainID, BIMIAuthType,
+		if err := a.createComplianceFinding(ctx, d.domainID, BIMIAuthType, bimiStandardName,
 			store.FindingSeverityLow, store.FindingStatusOpen, BIMIInvalidVMC,
 			"BIMI a= (VMC certificate) must reference an HTTPS URL"); err != nil {
 			return err
@@ -81,7 +81,7 @@ func (a *Assessor) assessBIMI(ctx context.Context, d assessData) error {
 	}
 
 	if !issues {
-		return a.createComplianceFinding(ctx, d.domainID, BIMIAuthType,
+		return a.createComplianceFinding(ctx, d.domainID, BIMIAuthType, bimiStandardName,
 			store.FindingSeverityInfo, store.FindingStatusClosed, BIMICompliant,
 			"BIMI is configured with a valid logo and enforced DMARC")
 	}
@@ -148,7 +148,7 @@ func isSVGURL(u string) bool {
 func (a *Assessor) createComplianceFinding(
 	ctx context.Context,
 	domainID int,
-	authType string,
+	authType, standardName string,
 	severity store.FindingSeverity,
 	status store.FindingStatus,
 	issueType, details string,
@@ -159,7 +159,7 @@ func (a *Assessor) createComplianceFinding(
 		Status:       status,
 		AuthType:     authType,
 		IssueType:    issueType,
-		StandardName: pgtype.Text{String: bimiStandardName, Valid: true},
+		StandardName: pgtype.Text{String: standardName, Valid: standardName != ""},
 		Details:      pgtype.Text{String: details, Valid: details != ""},
 	}); err != nil {
 		a.logger.WarnContext(ctx, "failed to create email auth compliance finding",

--- a/internal/assessor/assess_cname_test.go
+++ b/internal/assessor/assess_cname_test.go
@@ -26,6 +26,13 @@ func (f fakeProber) Probe(_ context.Context, target string) ProbeResult {
 	return ProbeResult{Reached: false}
 }
 
+func (f fakeProber) Get(_ context.Context, url string) ProbeResult {
+	if r, ok := f.results[url]; ok {
+		return r
+	}
+	return ProbeResult{Reached: false}
+}
+
 func danglingByTarget(
 	findings []store.DanglingCnameFindings,
 	target string,

--- a/internal/assessor/assess_email_security.go
+++ b/internal/assessor/assess_email_security.go
@@ -75,6 +75,7 @@ var (
 
 type assessData struct {
 	txtRecords   []store.TxtRecords
+	mxRecords    []store.MxRecords
 	domainID     int
 	handlesEmail bool
 }
@@ -524,6 +525,7 @@ func (a *Assessor) AssessEmailSecurity(ctx context.Context, domainID int) error 
 		handlesEmail: handlesEmail,
 		domainID:     domainID,
 		txtRecords:   txtRecords,
+		mxRecords:    mxRecords,
 	}
 
 	g, ctx := errgroup.WithContext(ctx)
@@ -538,6 +540,12 @@ func (a *Assessor) AssessEmailSecurity(ctx context.Context, domainID int) error 
 	})
 	g.Go(func() error {
 		return a.assessBIMI(ctx, as)
+	})
+	g.Go(func() error {
+		return a.assessMTASTS(ctx, as)
+	})
+	g.Go(func() error {
+		return a.assessTLSRPT(ctx, as)
 	})
 	if err := g.Wait(); err != nil {
 		return fmt.Errorf("assess email security: %w", err)

--- a/internal/assessor/assess_mta_sts.go
+++ b/internal/assessor/assess_mta_sts.go
@@ -1,0 +1,244 @@
+package assessor
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/danielmichaels/gecko/internal/store"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+const (
+	MTASTSAuthType     = "MTA-STS"
+	mtaStsStandardName = "MTA-STS RFC 8461"
+
+	MTASTSNotConfigured     = "mta_sts_not_configured"
+	MTASTSPolicyUnreachable = "mta_sts_policy_unreachable"
+	MTASTSModeNotEnforcing  = "mta_sts_mode_not_enforcing"
+	MTASTSMXMismatch        = "mta_sts_mx_mismatch"
+	MTASTSShortMaxAge       = "mta_sts_short_max_age"
+	MTASTSCompliant         = "mta_sts_compliant"
+
+	TLSRPTAuthType     = "TLS-RPT"
+	tlsRptStandardName = "TLS-RPT RFC 8460"
+
+	TLSRPTNotConfigured = "tls_rpt_not_configured"
+	TLSRPTInvalidRua    = "tls_rpt_invalid_rua"
+	TLSRPTCompliant     = "tls_rpt_compliant"
+)
+
+// mtaStsMinMaxAge is the policy max_age (seconds) below which MTA-STS offers weak
+// protection: a short window lets a downgrade attacker wait out the cached policy.
+// RFC 8461 recommends at least a few weeks; one week is the minimum we accept.
+const mtaStsMinMaxAge = 604800
+
+// assessMTASTS evaluates SMTP MTA Strict Transport Security: the _mta-sts TXT
+// record plus the HTTPS policy file. MTA-STS is opt-in, so its absence is recorded
+// as informational/not-applicable rather than a gap.
+func (a *Assessor) assessMTASTS(ctx context.Context, d assessData) error {
+	defer func() { a.logger.DebugContext(ctx, "assess MTA-STS complete", "domain_id", d.domainID) }()
+
+	if !d.handlesEmail {
+		return nil
+	}
+
+	domain, err := a.store.DomainsGetByIdentifier(ctx, store.DomainsGetByIdentifierParams{
+		TenantID: pgtype.Int4{Int32: a.identity.TenantID, Valid: true},
+		ID:       int32(d.domainID),
+	})
+	if err != nil {
+		return fmt.Errorf("get domain: %d %w", d.domainID, err)
+	}
+
+	if a.lookupTXTPrefixed("_mta-sts."+domain.Name, "v=STSv1") == "" {
+		return a.createComplianceFinding(ctx, d.domainID, MTASTSAuthType, mtaStsStandardName,
+			store.FindingSeverityInfo, store.FindingStatusNotApplicable, MTASTSNotConfigured,
+			"MTA-STS is not configured (optional SMTP transport-security policy)")
+	}
+
+	policyURL := "https://mta-sts." + domain.Name + "/.well-known/mta-sts.txt"
+	res := a.prober.Get(ctx, policyURL)
+	policy, ok := parseMTASTSPolicy(res.Body)
+	if !res.Reached || res.StatusCode != 200 || !ok {
+		return a.createComplianceFinding(
+			ctx,
+			d.domainID,
+			MTASTSAuthType,
+			mtaStsStandardName,
+			store.FindingSeverityLow,
+			store.FindingStatusOpen,
+			MTASTSPolicyUnreachable,
+			"MTA-STS TXT record is published but its HTTPS policy file could not be fetched or parsed",
+		)
+	}
+
+	issues := false
+	if policy.mode != "enforce" {
+		issues = true
+		if err := a.createComplianceFinding(ctx, d.domainID, MTASTSAuthType, mtaStsStandardName,
+			store.FindingSeverityLow, store.FindingStatusOpen, MTASTSModeNotEnforcing,
+			fmt.Sprintf("MTA-STS policy mode is %q; only mode=enforce protects mail in transit", policy.mode)); err != nil {
+			return err
+		}
+	}
+	if !mxSetCovered(policy.mx, d.mxRecords) {
+		issues = true
+		if err := a.createComplianceFinding(ctx, d.domainID, MTASTSAuthType, mtaStsStandardName,
+			store.FindingSeverityMedium, store.FindingStatusOpen, MTASTSMXMismatch,
+			"MTA-STS policy mx list does not cover the domain's published MX hosts"); err != nil {
+			return err
+		}
+	}
+	if policy.maxAge < mtaStsMinMaxAge {
+		issues = true
+		if err := a.createComplianceFinding(ctx, d.domainID, MTASTSAuthType, mtaStsStandardName,
+			store.FindingSeverityInfo, store.FindingStatusOpen, MTASTSShortMaxAge,
+			fmt.Sprintf("MTA-STS max_age is %ds; a short window weakens downgrade protection (recommend >= %ds)", policy.maxAge, mtaStsMinMaxAge)); err != nil {
+			return err
+		}
+	}
+
+	if issues {
+		return nil
+	}
+	return a.createComplianceFinding(ctx, d.domainID, MTASTSAuthType, mtaStsStandardName,
+		store.FindingSeverityInfo, store.FindingStatusClosed, MTASTSCompliant,
+		"MTA-STS is enforced with a valid policy covering the published MX hosts")
+}
+
+// assessTLSRPT evaluates SMTP TLS Reporting: the _smtp._tls TXT record and its
+// rua reporting endpoint. Like MTA-STS it is opt-in.
+func (a *Assessor) assessTLSRPT(ctx context.Context, d assessData) error {
+	defer func() { a.logger.DebugContext(ctx, "assess TLS-RPT complete", "domain_id", d.domainID) }()
+
+	if !d.handlesEmail {
+		return nil
+	}
+
+	domain, err := a.store.DomainsGetByIdentifier(ctx, store.DomainsGetByIdentifierParams{
+		TenantID: pgtype.Int4{Int32: a.identity.TenantID, Valid: true},
+		ID:       int32(d.domainID),
+	})
+	if err != nil {
+		return fmt.Errorf("get domain: %d %w", d.domainID, err)
+	}
+
+	record := a.lookupTXTPrefixed("_smtp._tls."+domain.Name, "v=TLSRPTv1")
+	if record == "" {
+		return a.createComplianceFinding(ctx, d.domainID, TLSRPTAuthType, tlsRptStandardName,
+			store.FindingSeverityInfo, store.FindingStatusNotApplicable, TLSRPTNotConfigured,
+			"TLS-RPT is not configured (optional SMTP TLS reporting policy)")
+	}
+
+	if !tlsRptHasValidRua(record) {
+		return a.createComplianceFinding(ctx, d.domainID, TLSRPTAuthType, tlsRptStandardName,
+			store.FindingSeverityLow, store.FindingStatusOpen, TLSRPTInvalidRua,
+			"TLS-RPT record has no valid rua reporting endpoint (expected mailto: or https:)")
+	}
+
+	return a.createComplianceFinding(ctx, d.domainID, TLSRPTAuthType, tlsRptStandardName,
+		store.FindingSeverityInfo, store.FindingStatusClosed, TLSRPTCompliant,
+		"TLS-RPT is configured with a valid reporting endpoint")
+}
+
+func (a *Assessor) lookupTXTPrefixed(name, prefix string) string {
+	records, found := a.dnsClient.LookupTXT(name)
+	if !found {
+		return ""
+	}
+	for _, r := range records {
+		if strings.HasPrefix(strings.TrimSpace(r), prefix) {
+			return r
+		}
+	}
+	return ""
+}
+
+// mtaStsPolicy is the parsed MTA-STS policy file (RFC 8461 §3.2).
+type mtaStsPolicy struct {
+	mode   string
+	mx     []string
+	maxAge int
+}
+
+// parseMTASTSPolicy parses the line-based "key: value" policy body. It reports ok
+// only when the mandatory version/mode/mx fields are present.
+func parseMTASTSPolicy(body string) (mtaStsPolicy, bool) {
+	var p mtaStsPolicy
+	var version string
+	for _, line := range strings.Split(body, "\n") {
+		line = strings.TrimSpace(line)
+		key, value, found := strings.Cut(line, ":")
+		if !found {
+			continue
+		}
+		value = strings.TrimSpace(value)
+		switch strings.ToLower(strings.TrimSpace(key)) {
+		case "version":
+			version = value
+		case "mode":
+			p.mode = strings.ToLower(value)
+		case "mx":
+			if value != "" {
+				p.mx = append(p.mx, value)
+			}
+		case "max_age":
+			p.maxAge, _ = strconv.Atoi(value)
+		}
+	}
+	if version == "" || p.mode == "" || len(p.mx) == 0 {
+		return p, false
+	}
+	return p, true
+}
+
+// mxSetCovered reports whether every published MX host is matched by at least one
+// MTA-STS policy mx pattern. An empty published MX set is trivially covered.
+func mxSetCovered(patterns []string, mxRecords []store.MxRecords) bool {
+	for _, mx := range mxRecords {
+		host := strings.TrimSuffix(strings.ToLower(strings.TrimSpace(mx.Target)), ".")
+		if host == "" {
+			continue
+		}
+		matched := false
+		for _, pat := range patterns {
+			if mtaStsMxMatch(pat, host) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+	return true
+}
+
+// mtaStsMxMatch matches one policy mx pattern against a host, supporting the
+// single-label "*.example.com" wildcard form (RFC 8461 §4.1).
+func mtaStsMxMatch(pattern, host string) bool {
+	pattern = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(pattern)), ".")
+	if strings.HasPrefix(pattern, "*.") {
+		return strings.HasSuffix(host, pattern[1:])
+	}
+	return pattern == host
+}
+
+func tlsRptHasValidRua(record string) bool {
+	for _, part := range strings.Split(record, ";") {
+		part = strings.TrimSpace(part)
+		key, value, found := strings.Cut(part, "=")
+		if !found || !strings.EqualFold(strings.TrimSpace(key), "rua") {
+			continue
+		}
+		for _, endpoint := range strings.Split(value, ",") {
+			endpoint = strings.ToLower(strings.TrimSpace(endpoint))
+			if strings.HasPrefix(endpoint, "mailto:") || strings.HasPrefix(endpoint, "https:") {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/assessor/assess_mta_sts_test.go
+++ b/internal/assessor/assess_mta_sts_test.go
@@ -1,0 +1,229 @@
+package assessor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/danielmichaels/gecko/internal/dnsclient"
+	"github.com/danielmichaels/gecko/internal/observer"
+	"github.com/danielmichaels/gecko/internal/store"
+	"github.com/danielmichaels/gecko/internal/testhelpers"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/miekg/dns"
+)
+
+func TestAssessMTASTSAndTLSRPT(t *testing.T) {
+	ctx := context.Background()
+	pgContainer, err := testhelpers.CreatePostgresContainer(ctx)
+	if err != nil {
+		t.Fatalf("Failed to create postgres container: %v", err)
+	}
+	defer pgContainer.Close(ctx)
+
+	mockServer, err := testhelpers.NewMockDNSServer()
+	if err != nil {
+		t.Fatalf("Failed to create mock DNS server: %v", err)
+	}
+	if err := mockServer.Start(); err != nil {
+		t.Fatalf("Failed to start mock DNS server: %v", err)
+	}
+	defer func() { _ = mockServer.Stop() }()
+
+	dnsClient := dnsclient.New(
+		dnsclient.WithServers([]string{mockServer.ListenAddr}),
+		dnsclient.WithLogger(testhelpers.TestLogger),
+	)
+
+	policyURL := func(domain string) string {
+		return "https://mta-sts." + domain + "/.well-known/mta-sts.txt"
+	}
+
+	newDomain := func(t *testing.T, name string) store.DomainsCreateRow {
+		t.Helper()
+		d, err := pgContainer.Queries.DomainsCreate(ctx, store.DomainsCreateParams{
+			TenantID:   pgtype.Int4{Int32: 1, Valid: true},
+			Name:       name,
+			DomainType: store.DomainTypeTld,
+			Source:     store.DomainSourceUserSupplied,
+			Status:     store.DomainStatusActive,
+		})
+		if err != nil {
+			t.Fatalf("create domain: %v", err)
+		}
+		return d
+	}
+
+	finding := func(t *testing.T, d store.DomainsCreateRow, authType, issueType string) (store.EmailAuthComplianceFindings, bool) {
+		t.Helper()
+		fs, err := pgContainer.Queries.AssessGetEmailAuthComplianceFindingsByDomainUID(ctx,
+			store.AssessGetEmailAuthComplianceFindingsByDomainUIDParams{
+				Uid: d.Uid, TenantID: pgtype.Int4{Int32: 1, Valid: true},
+			})
+		if err != nil {
+			t.Fatalf("get compliance findings: %v", err)
+		}
+		for _, f := range fs {
+			if f.AuthType == authType && f.IssueType == issueType {
+				return f, true
+			}
+		}
+		return store.EmailAuthComplianceFindings{}, false
+	}
+
+	runMTASTS := func(t *testing.T, d store.DomainsCreateRow, prober HTTPProber, mx []store.MxRecords) {
+		t.Helper()
+		a := NewAssessor(Config{
+			Store:      pgContainer.Queries,
+			Logger:     testhelpers.TestLogger,
+			DNSClient:  dnsClient,
+			HTTPProber: prober,
+			Identity:   observer.DomainIdentity{TenantID: 1, DomainID: d.ID},
+		})
+		if err := a.assessMTASTS(ctx, assessData{handlesEmail: true, domainID: int(d.ID), mxRecords: mx}); err != nil {
+			t.Fatalf("assessMTASTS: %v", err)
+		}
+	}
+	runTLSRPT := func(t *testing.T, d store.DomainsCreateRow) {
+		t.Helper()
+		a := NewAssessor(Config{
+			Store:     pgContainer.Queries,
+			Logger:    testhelpers.TestLogger,
+			DNSClient: dnsClient,
+			Identity:  observer.DomainIdentity{TenantID: 1, DomainID: d.ID},
+		})
+		if err := a.assessTLSRPT(ctx, assessData{handlesEmail: true, domainID: int(d.ID)}); err != nil {
+			t.Fatalf("assessTLSRPT: %v", err)
+		}
+	}
+
+	mxOf := func(host string) []store.MxRecords {
+		return []store.MxRecords{{Preference: 10, Target: host}}
+	}
+
+	t.Run("no MTA-STS record is informational and not-applicable", func(t *testing.T) {
+		d := newDomain(t, "no-mtasts.test")
+		runMTASTS(t, d, fakeProber{}, mxOf("mail.no-mtasts.test"))
+
+		f, ok := finding(t, d, MTASTSAuthType, MTASTSNotConfigured)
+		if !ok {
+			t.Fatalf("expected mta_sts_not_configured finding")
+		}
+		if f.Severity != store.FindingSeverityInfo || f.Status != store.FindingStatusNotApplicable {
+			t.Errorf("expected info/not_applicable, got %s/%s", f.Severity, f.Status)
+		}
+	})
+
+	t.Run("enforce policy with matching MX is compliant", func(t *testing.T) {
+		d := newDomain(t, "good-mtasts.test")
+		if err := mockServer.AddRecord("_mta-sts."+d.Name, dns.TypeTXT, 3600, "v=STSv1; id=20240101T000000Z"); err != nil {
+			t.Fatalf("mock txt: %v", err)
+		}
+		prober := fakeProber{results: map[string]ProbeResult{
+			policyURL(d.Name): {
+				Reached:    true,
+				StatusCode: 200,
+				Body:       "version: STSv1\nmode: enforce\nmx: mail.good-mtasts.test\nmax_age: 604800\n",
+			},
+		}}
+		runMTASTS(t, d, prober, mxOf("mail.good-mtasts.test"))
+
+		f, ok := finding(t, d, MTASTSAuthType, MTASTSCompliant)
+		if !ok {
+			t.Fatalf("expected mta_sts_compliant finding")
+		}
+		if f.Status != store.FindingStatusClosed {
+			t.Errorf("expected closed, got %s", f.Status)
+		}
+	})
+
+	t.Run("testing mode is flagged as not enforcing", func(t *testing.T) {
+		d := newDomain(t, "testing-mtasts.test")
+		if err := mockServer.AddRecord("_mta-sts."+d.Name, dns.TypeTXT, 3600, "v=STSv1; id=abc"); err != nil {
+			t.Fatalf("mock txt: %v", err)
+		}
+		prober := fakeProber{results: map[string]ProbeResult{
+			policyURL(d.Name): {
+				Reached:    true,
+				StatusCode: 200,
+				Body:       "version: STSv1\nmode: testing\nmx: mail.testing-mtasts.test\nmax_age: 604800\n",
+			},
+		}}
+		runMTASTS(t, d, prober, mxOf("mail.testing-mtasts.test"))
+
+		f, ok := finding(t, d, MTASTSAuthType, MTASTSModeNotEnforcing)
+		if !ok {
+			t.Fatalf("expected mta_sts_mode_not_enforcing finding")
+		}
+		if f.Severity != store.FindingSeverityLow || f.Status != store.FindingStatusOpen {
+			t.Errorf("expected low/open, got %s/%s", f.Severity, f.Status)
+		}
+	})
+
+	t.Run("policy MX not covering actual MX is a medium mismatch", func(t *testing.T) {
+		d := newDomain(t, "mismatch-mtasts.test")
+		if err := mockServer.AddRecord("_mta-sts."+d.Name, dns.TypeTXT, 3600, "v=STSv1; id=abc"); err != nil {
+			t.Fatalf("mock txt: %v", err)
+		}
+		prober := fakeProber{results: map[string]ProbeResult{
+			policyURL(d.Name): {
+				Reached:    true,
+				StatusCode: 200,
+				Body:       "version: STSv1\nmode: enforce\nmx: other-host.example\nmax_age: 604800\n",
+			},
+		}}
+		runMTASTS(t, d, prober, mxOf("mail.mismatch-mtasts.test"))
+
+		f, ok := finding(t, d, MTASTSAuthType, MTASTSMXMismatch)
+		if !ok {
+			t.Fatalf("expected mta_sts_mx_mismatch finding")
+		}
+		if f.Severity != store.FindingSeverityMedium || f.Status != store.FindingStatusOpen {
+			t.Errorf("expected medium/open, got %s/%s", f.Severity, f.Status)
+		}
+	})
+
+	t.Run("unreachable policy is flagged", func(t *testing.T) {
+		d := newDomain(t, "unreachable-mtasts.test")
+		if err := mockServer.AddRecord("_mta-sts."+d.Name, dns.TypeTXT, 3600, "v=STSv1; id=abc"); err != nil {
+			t.Fatalf("mock txt: %v", err)
+		}
+		runMTASTS(t, d, fakeProber{}, mxOf("mail.unreachable-mtasts.test"))
+
+		f, ok := finding(t, d, MTASTSAuthType, MTASTSPolicyUnreachable)
+		if !ok {
+			t.Fatalf("expected mta_sts_policy_unreachable finding")
+		}
+		if f.Severity != store.FindingSeverityLow || f.Status != store.FindingStatusOpen {
+			t.Errorf("expected low/open, got %s/%s", f.Severity, f.Status)
+		}
+	})
+
+	t.Run("no TLS-RPT record is informational", func(t *testing.T) {
+		d := newDomain(t, "no-tlsrpt.test")
+		runTLSRPT(t, d)
+
+		f, ok := finding(t, d, TLSRPTAuthType, TLSRPTNotConfigured)
+		if !ok {
+			t.Fatalf("expected tls_rpt_not_configured finding")
+		}
+		if f.Severity != store.FindingSeverityInfo {
+			t.Errorf("expected info, got %s", f.Severity)
+		}
+	})
+
+	t.Run("valid TLS-RPT record is compliant", func(t *testing.T) {
+		d := newDomain(t, "good-tlsrpt.test")
+		if err := mockServer.AddRecord("_smtp._tls."+d.Name, dns.TypeTXT, 3600, "v=TLSRPTv1; rua=mailto:tls@good-tlsrpt.test"); err != nil {
+			t.Fatalf("mock txt: %v", err)
+		}
+		runTLSRPT(t, d)
+
+		f, ok := finding(t, d, TLSRPTAuthType, TLSRPTCompliant)
+		if !ok {
+			t.Fatalf("expected tls_rpt_compliant finding")
+		}
+		if f.Status != store.FindingStatusClosed {
+			t.Errorf("expected closed, got %s", f.Status)
+		}
+	})
+}

--- a/internal/assessor/prober.go
+++ b/internal/assessor/prober.go
@@ -24,8 +24,11 @@ type ProbeResult struct {
 
 // HTTPProber probes a CNAME target over HTTP(S). It is an interface so the
 // assessor can be unit-tested with a deterministic fake instead of real egress.
+// Get fetches an exact HTTPS URL (used for the MTA-STS policy file); it follows
+// no redirects and reads a bounded body prefix.
 type HTTPProber interface {
 	Probe(ctx context.Context, target string) ProbeResult
+	Get(ctx context.Context, url string) ProbeResult
 }
 
 type httpProber struct {
@@ -56,6 +59,14 @@ func (p *httpProber) Probe(ctx context.Context, target string) ProbeResult {
 		}
 	}
 	return ProbeResult{Reached: false}
+}
+
+// Get fetches an exact URL (no scheme inference, no HTTP fallback), returning the
+// bounded response. Used for the MTA-STS policy file, which must be retrieved over
+// HTTPS at a fixed path with redirects suppressed.
+func (p *httpProber) Get(ctx context.Context, url string) ProbeResult {
+	res, _ := p.do(ctx, url)
+	return res
 }
 
 func (p *httpProber) do(ctx context.Context, url string) (ProbeResult, bool) {

--- a/internal/service/findings.go
+++ b/internal/service/findings.go
@@ -689,6 +689,15 @@ var findingTitles = map[string]string{
 	"bimi_requires_enforced_dmarc": "BIMI requires enforced DMARC",
 	"bimi_invalid_logo":            "BIMI logo URL invalid",
 	"bimi_invalid_vmc":             "BIMI VMC certificate URL invalid",
+	"mta_sts_not_configured":       "MTA-STS not configured (optional)",
+	"mta_sts_policy_unreachable":   "MTA-STS policy file unreachable",
+	"mta_sts_mode_not_enforcing":   "MTA-STS not in enforce mode",
+	"mta_sts_mx_mismatch":          "MTA-STS policy MX doesn't match",
+	"mta_sts_short_max_age":        "MTA-STS max_age too short",
+	"mta_sts_compliant":            "MTA-STS correctly enforced",
+	"tls_rpt_not_configured":       "TLS-RPT not configured (optional)",
+	"tls_rpt_invalid_rua":          "TLS-RPT has no valid rua endpoint",
+	"tls_rpt_compliant":            "TLS-RPT correctly configured",
 }
 
 // findingDescriptions holds static descriptions for findings whose body text is
@@ -746,4 +755,9 @@ var findingFixes = map[string]string{
 	"bimi_requires_enforced_dmarc": "Enforce DMARC (p=quarantine or p=reject) before publishing BIMI.",
 	"bimi_invalid_logo":            "Point BIMI l= at an HTTPS URL serving an SVG Tiny PS logo.",
 	"bimi_invalid_vmc":             "Point BIMI a= at an HTTPS URL serving the VMC certificate.",
+	"mta_sts_policy_unreachable":   "Serve the policy at https://mta-sts.<domain>/.well-known/mta-sts.txt over HTTPS.",
+	"mta_sts_mode_not_enforcing":   "Set mode: enforce in the MTA-STS policy once testing confirms delivery.",
+	"mta_sts_mx_mismatch":          "List every published MX host in the MTA-STS policy mx: lines.",
+	"mta_sts_short_max_age":        "Raise the MTA-STS policy max_age to at least 604800 (one week).",
+	"tls_rpt_invalid_rua":          "Set a valid TLS-RPT rua endpoint, e.g. rua=mailto:tls-reports@example.com.",
 }


### PR DESCRIPTION
Adds the SMTP **transport-security** layer (MTA-STS + TLS-RPT) that complements the shipped SPF/DKIM/DMARC/BIMI checks (EPIC #61).

## Approach

Reuses `email_auth_compliance_findings` (`auth_type` = `MTA-STS` / `TLS-RPT`) and folds into `AssessEmailSecurity` as two errgroup sub-assessors gated on `handlesEmail` — the exact BIMI precedent. **No migration, no sqlc, no new job/worker, no new surfacing kind**; everything flows through the existing `EMAIL_COMPLIANCE` feed.

## Checks

**MTA-STS** (RFC 8461) — `_mta-sts` TXT + HTTPS policy fetch:
| issue_type | severity |
|---|---|
| `mta_sts_not_configured` | info / not-applicable |
| `mta_sts_policy_unreachable` | low |
| `mta_sts_mode_not_enforcing` (testing/none) | low |
| `mta_sts_mx_mismatch` | medium |
| `mta_sts_short_max_age` (<1 week) | info |
| `mta_sts_compliant` | closed |

**TLS-RPT** (RFC 8460) — `_smtp._tls` TXT:
| issue_type | severity |
|---|---|
| `tls_rpt_not_configured` | info / not-applicable |
| `tls_rpt_invalid_rua` | low |
| `tls_rpt_compliant` | closed |

Severities follow the "adoption-friendly" calibration (absence is informational, active misconfig like MX-mismatch is medium).

## Notes

- **Cost:** one HTTPS GET per mail domain to `mta-sts.<domain>/.well-known/mta-sts.txt` via a new `HTTPProber.Get` — HTTPS-only, no redirects, 8KB-bounded body, 5s timeout. The `_mta-sts`/`_smtp._tls` TXT lookups go through the cached/rate-limited resolver.
- `createComplianceFinding` now takes the standard name, so MTA-STS / TLS-RPT / BIMI each carry their own (`MTA-STS RFC 8461`, `TLS-RPT RFC 8460`, BIMI).
- Gated on `handlesEmail`, so null-MX / non-mail domains are skipped.

Closes #66
